### PR TITLE
Convert a DiffGraph to a DiffTree by equipping it with a synthetic root.

### DIFF
--- a/src/main/java/diff/difftree/DiffGraph.java
+++ b/src/main/java/diff/difftree/DiffGraph.java
@@ -3,6 +3,8 @@ package diff.difftree;
 import java.util.Collection;
 
 public final class DiffGraph {
+    private static final String DIFFGRAPH_LABEL = "DiffGraph";
+
     private DiffGraph() {}
 
     private static boolean hasNoParents(final DiffNode node) {
@@ -26,6 +28,7 @@ public final class DiffGraph {
      */
     public static DiffTree fromNodes(final Collection<DiffNode> nodes, final DiffTreeSource source) {
         final DiffNode newRoot = DiffNode.createRoot();
+        newRoot.setLabel(DIFFGRAPH_LABEL);
         nodes.stream()
                 .filter(DiffGraph::hasNoParents)
                 .forEach(n ->


### PR DESCRIPTION
closes #4 

Instead of creating a new datatype to represent DiffGraphs, we just add a synthetic root to it to create a DiffTree that we can reuse everywhere. We do so by adding those nodes as children of the root that have no parents in the directed acyclic DiffGraph (i.e., nodes that could be roots).