### PR TITLE
Enable javadoc generation using maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,15 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.4.0</version>
+                <configuration>
+                    <reportOutputDirectory>docs</reportOutputDirectory>
+                    <destDir>javadoc</destDir>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>

--- a/src/main/java/org/variantsync/diffdetective/datasets/Repository.java
+++ b/src/main/java/org/variantsync/diffdetective/datasets/Repository.java
@@ -92,7 +92,7 @@ public class Repository {
 	/**
 	 * Creates a repository from an existing directory.
 	 * 
-	 * @param dirPath The path to the repo directory relative to <WORKING_DIRECTORY>/repositories
+	 * @param dirPath The path to the repo directory relative to {@code <WORKING_DIRECTORY>/repositories}
 	 * @param repoName A name for the repository (currently not used)
 	 * @return A repository from an existing directory
 	 */
@@ -107,7 +107,7 @@ public class Repository {
 	/**
 	 * Creates a repository from a local zip file.
 	 * 
-	 * @param filePath The path to the zip file (absolute or relative to <WORKING_DIRECTORY>).
+	 * @param filePath The path to the zip file (absolute or relative to {@code <WORKING_DIRECTORY>}).
 	 * @param repoName A name for the repository (currently not used)
 	 * @return A repository from a local zip file
 	 */

--- a/src/main/java/org/variantsync/diffdetective/diff/GitDiffer.java
+++ b/src/main/java/org/variantsync/diffdetective/diff/GitDiffer.java
@@ -238,8 +238,7 @@ public class GitDiffer {
      *
      * @param git The git repo which the commit stems from
      * @param commit The commit which the working tree is compared with
-     * @param keepFullDiffs  If true, the PatchDiff will contain the full diff as a string. Set to false if you want to
-     *                       reduce memory consumption
+     * @param parseOptions {@link ParseOptions}
      * @return The CommitDiff of the given commit
      */
     public static CommitDiffResult createWorkingTreeDiff(

--- a/src/main/java/org/variantsync/diffdetective/diff/difftree/DiffGraph.java
+++ b/src/main/java/org/variantsync/diffdetective/diff/difftree/DiffGraph.java
@@ -12,7 +12,7 @@ public final class DiffGraph {
     }
 
     /**
-     * Invokes {@link DiffGraph::fromNodes(Collection<DiffNode>)} with an unknown DiffTreeSource.
+     * Invokes {@link DiffGraph#fromNodes(Collection<DiffNode>)} with an unknown DiffTreeSource.
      */
     public static DiffTree fromNodes(final Collection<DiffNode> nodes) {
         return fromNodes(nodes, DiffTreeSource.Unknown);
@@ -24,7 +24,7 @@ public final class DiffGraph {
      * @param nodes a DiffGraph
      * @param source the source where the DiffGraph came from.
      * @return A DiffTree representing the DiffGraph with a synthetic root node.
-     * see DiffGraph.fromNodes(Collection<DiffNode>)
+     * @see DiffGraph#fromNodes(Collection<DiffNode>)
      */
     public static DiffTree fromNodes(final Collection<DiffNode> nodes, final DiffTreeSource source) {
         final DiffNode newRoot = DiffNode.createRoot();

--- a/src/main/java/org/variantsync/diffdetective/mining/postprocessing/MiningPostprocessing.java
+++ b/src/main/java/org/variantsync/diffdetective/mining/postprocessing/MiningPostprocessing.java
@@ -80,7 +80,7 @@ public class MiningPostprocessing {
      * non-recursive
      * @param path A path to a linegraph file or a directory containing linegraph files.
      * @return The list of all diffgraphs parsed from linegraph files in the given directory.
-     * @throws IOException If the directory could not be accessed ({@link Files::list}).
+     * @throws IOException If the directory could not be accessed ({@link Files#list}).
      */
     public static List<DiffTree> parseFrequentSubgraphsIn(final Path path) throws IOException {
         if (Files.isDirectory(path)) {

--- a/src/main/java/org/variantsync/diffdetective/util/fide/FixTrueFalse.java
+++ b/src/main/java/org/variantsync/diffdetective/util/fide/FixTrueFalse.java
@@ -28,7 +28,7 @@ public class FixTrueFalse {
 
     /**
      * @return True iff the given formula is a true literal.
-     * @see FixTrueFalse::isTrueLiteral
+     * @see FixTrueFalse#isTrueLiteral
      */
     public static boolean isTrue(final Node n) {
         return n instanceof Literal l && isTrueLiteral(l);
@@ -36,7 +36,7 @@ public class FixTrueFalse {
 
     /**
      * @return True iff the given formula is a false literal.
-     * @see FixTrueFalse::isFalseLiteral
+     * @see FixTrueFalse#isFalseLiteral
      */
     public static boolean isFalse(final Node n) {
         return n instanceof Literal l && isFalseLiteral(l);
@@ -77,7 +77,7 @@ public class FixTrueFalse {
 
     /**
      * Replaces all literals in the given `formula` with the literals True and False that
-     * represent the respective atomic values w.r.t. FixTrueFalse::isTrueLiteral and FixTrueFalse::isFalseLiteral.
+     * represent the respective atomic values w.r.t. FixTrueFalse.isTrueLiteral and FixTrueFalse.isFalseLiteral.
      * This e.g. includes replacing literals representing variables with name "1" or "true" with the respective constants.
      * Returns a formula in which the values True and False are eliminated.
      * So you either get True, False, or a formula that does not contain any True or False value.


### PR DESCRIPTION
The documentation can now be build by `mvn javadoc:javadoc` and viewed
by opening `target/site/apidocs/index.html` in a browser

The changed documentation is due to errors in the javadoc syntax which
caused the javadoc tool to report errors and stop processing these
files.