### PR TITLE
Differentiate between #if A and #if defined(A)

### DIFF
--- a/src/main/java/org/variantsync/diffdetective/feature/CPPDiffLineFormulaExtractor.java
+++ b/src/main/java/org/variantsync/diffdetective/feature/CPPDiffLineFormulaExtractor.java
@@ -60,7 +60,7 @@ public class CPPDiffLineFormulaExtractor {
         fm = COMMENT_PATTERN.matcher(fm).replaceAll("");
 
         // remove defined()
-        fm = DEFINED_PATTERN.matcher(fm).replaceAll("$2");
+        fm = DEFINED_PATTERN.matcher(fm).replaceAll("DEFINED_$2");
 
         // remove whitespace
         fm = fm.replaceAll("\\s", "");

--- a/src/main/java/org/variantsync/diffdetective/feature/CPPDiffLineFormulaExtractor.java
+++ b/src/main/java/org/variantsync/diffdetective/feature/CPPDiffLineFormulaExtractor.java
@@ -19,7 +19,7 @@ public class CPPDiffLineFormulaExtractor {
     private static final String CPP_ANNOTATION_REGEX = "^[+-]?\\s*#\\s*(if|ifdef|ifndef|elif)(\\s+(.*)|\\((.*)\\))$";
     private static final Pattern CPP_ANNOTATION_REGEX_PATTERN = Pattern.compile(CPP_ANNOTATION_REGEX);
     private static final Pattern COMMENT_PATTERN = Pattern.compile("/\\*.*?\\*/");
-    private static final Pattern DEFINED_PATTERN = Pattern.compile("\\bdefined\\b(\\s*\\((\\w*)\\))?");
+    private static final Pattern DEFINED_PATTERN = Pattern.compile("\\bdefined\\b(\\s*\\(\\s*(\\w*)\\s*\\))?");
 
     /**
      * Resolves any macros in the given formula that are relevant for feature annotations.

--- a/src/test/java/CPPParserTest.java
+++ b/src/test/java/CPPParserTest.java
@@ -45,6 +45,7 @@ public class CPPParserTest {
             new TestCase("#if defined A", "DEFINED_A"),
             new TestCase("#if defined(A)", "DEFINED_A"),
             new TestCase("#if defined (A)", "DEFINED_A"),
+            new TestCase("#if defined ( A )", "DEFINED_A"),
             new TestCase("#if (defined A)", "__LB__DEFINED_A__RB__"),
             new TestCase("#if MACRO (A)", "MACRO__LB__A__RB__"),
             new TestCase("#if MACRO (A, B)", "MACRO__LB__A__B__RB__"),

--- a/src/test/java/CPPParserTest.java
+++ b/src/test/java/CPPParserTest.java
@@ -34,7 +34,7 @@ public class CPPParserTest {
             new TestCase("#if A ? B : C", "A__THEN__B__ELSE__C"),
             new TestCase("#if A >= B && C > D", "A__GEQ__B&&C__GT__D"),
             new TestCase("#if A * (B + C)", "A__MUL____LB__B__ADD__C__RB__"),
-            new TestCase("#if defined(A) && (B * 2) > C", "A&&__LB__B__MUL__2__RB____GT__C"),
+            new TestCase("#if defined(A) && (B * 2) > C", "DEFINED_A&&__LB__B__MUL__2__RB____GT__C"),
 
             new TestCase("#if A // Comment && B", "A"),
             new TestCase("#if A /* Comment */ && B", "A&&B"),
@@ -42,10 +42,10 @@ public class CPPParserTest {
             new TestCase("#if A == B", "A__EQ__B"),
             new TestCase("#if A == 1", "A__EQ__1"),
 
-            new TestCase("#if defined A", "A"),
-            new TestCase("#if defined(A)", "A"),
-            new TestCase("#if defined (A)", "A"),
-            new TestCase("#if (defined A)", "__LB__A__RB__"),
+            new TestCase("#if defined A", "DEFINED_A"),
+            new TestCase("#if defined(A)", "DEFINED_A"),
+            new TestCase("#if defined (A)", "DEFINED_A"),
+            new TestCase("#if (defined A)", "__LB__DEFINED_A__RB__"),
             new TestCase("#if MACRO (A)", "MACRO__LB__A__RB__"),
             new TestCase("#if MACRO (A, B)", "MACRO__LB__A__B__RB__"),
             new TestCase("#if MACRO (A, B + C)", "MACRO__LB__A__B__ADD__C__RB__"),
@@ -67,8 +67,7 @@ public class CPPParserTest {
             // Empty formula
             new ThrowingTestCase("#ifdef"),
             new ThrowingTestCase("#ifdef // Comment"),
-            new ThrowingTestCase("#ifdef /* Comment */"),
-            new ThrowingTestCase("#if defined()")
+            new ThrowingTestCase("#ifdef /* Comment */")
         );
     }
 

--- a/src/test/resources/diffs/parser/12_expected.lg
+++ b/src/test/resources/diffs/parser/12_expected.lg
@@ -1,5 +1,5 @@
 v 16 NON;IF;(old: -1, diff: -1, new:-1);(old: -1, diff: -1, new:-1);True
-v 144 NON;IF;(old: 1, diff: 1, new:1);(old: 3, diff: 3, new:3);A;#if defined(A)
+v 144 NON;IF;(old: 1, diff: 1, new:1);(old: 3, diff: 3, new:3);DEFINED_A;#if defined(A)
 v 211 NON;ARTIFACT;(old: 2, diff: 2, new:2);(old: 3, diff: 3, new:3);;Code
 e 144 16 ba;0;0
 e 211 144 ba;0;0


### PR DESCRIPTION
This patch relaxes the CPP formula parser to also accept `#if defined()` although it has an invalid formula. It would make the code very ugly to test for this case so I left it out.