### PR TITLE
Some old updates and refactorings to the tikz exporter

### DIFF
--- a/src/main/java/org/variantsync/diffdetective/internal/TextDiffToTikz.java
+++ b/src/main/java/org/variantsync/diffdetective/internal/TextDiffToTikz.java
@@ -1,0 +1,109 @@
+package org.variantsync.diffdetective.internal;
+
+import org.tinylog.Logger;
+import org.variantsync.diffdetective.diff.result.DiffError;
+import org.variantsync.diffdetective.diff.result.DiffParseException;
+import org.variantsync.diffdetective.util.FileUtils;
+import org.variantsync.diffdetective.util.IO;
+import org.variantsync.diffdetective.variation.diff.DiffNode;
+import org.variantsync.diffdetective.variation.diff.DiffTree;
+import org.variantsync.diffdetective.variation.diff.parse.DiffTreeParseOptions;
+import org.variantsync.diffdetective.variation.diff.serialize.Format;
+import org.variantsync.diffdetective.variation.diff.serialize.GraphvizExporter;
+import org.variantsync.diffdetective.variation.diff.serialize.TikzExporter;
+import org.variantsync.diffdetective.variation.diff.serialize.edgeformat.DefaultEdgeLabelFormat;
+import org.variantsync.diffdetective.variation.diff.serialize.edgeformat.EdgeLabelFormat;
+import org.variantsync.functjonal.Result;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TextDiffToTikz {
+    public static String[] UNICODE_PROP_SYMBOLS = new String[]{"¬", "∧", "∨", "⇒", "⇔"};
+
+    /**
+     * Format used for the test export.
+     */
+    private final static Format format =
+            new Format(
+                    TextDiffToTikz::tikzNodeLabel,
+                    // There is a bug in the exporter currently that accidentally switches direction so as a workaround we revert it here.
+                    new DefaultEdgeLabelFormat(EdgeLabelFormat.Direction.ParentToChild)
+            );
+
+    public static void main(String[] args) throws IOException, DiffParseException {
+        if (args.length < 1) {
+            System.err.println("Expected a path to a diff file or directory as first argument.");
+            return;
+        }
+
+        final GraphvizExporter.LayoutAlgorithm layout;
+        if (args.length < 2) {
+            layout = GraphvizExporter.LayoutAlgorithm.DOT;
+        } else {
+            layout = GraphvizExporter.LayoutAlgorithm.valueOf(args[1].toUpperCase());
+        }
+
+        final Path fileToConvert = Path.of(args[0]);
+        if (!Files.exists(fileToConvert)) {
+            Logger.error("Path {} does not exist!", fileToConvert);
+            return;
+        }
+
+        if (Files.isDirectory(fileToConvert)) {
+            Logger.info("Processing directory " + fileToConvert);
+            for (Path file : FileUtils.listAllFilesRecursively(fileToConvert)) {
+                if (FileUtils.hasExtension(file, ".diff")) {
+                    textDiff2Tikz(file, layout);
+                }
+            }
+        } else {
+            textDiff2Tikz(fileToConvert, layout);
+        }
+    }
+
+    public static void textDiff2Tikz(Path fileToConvert, GraphvizExporter.LayoutAlgorithm layout) throws IOException, DiffParseException {
+        Logger.info("Converting file " + fileToConvert);
+        Logger.info("Using layout " + layout.getExecutableName());
+        final Path targetFile = fileToConvert.resolveSibling(fileToConvert.getFileName() + ".tikz");
+
+        final DiffTree d = DiffTree.fromFile(fileToConvert, new DiffTreeParseOptions(true, true));
+        final String tikz = exportAsTikz(d, layout);
+        IO.write(targetFile, tikz);
+        Logger.info("Wrote file " + targetFile);
+    }
+
+    public static String exportAsTikz(final DiffTree diffTree, GraphvizExporter.LayoutAlgorithm layout) throws IOException {
+        // Export the test case
+        var tikzOutput = new ByteArrayOutputStream();
+        new TikzExporter(format).exportDiffTree(diffTree, layout, tikzOutput);
+        return tikzOutput.toString();
+    }
+
+    public static String tikzNodeLabel(DiffNode node) {
+        if (node.isRoot()) {
+            return "r";
+        } else {
+            if (node.isIf() || node.isElif()) {
+                return node.getFormula().toString(UNICODE_PROP_SYMBOLS);
+            } else {
+                return node.getLabel().lines().get(0).trim();
+            }
+//                    .map(String::trim)
+//                    .collect(Collectors.joining("<br>"));// substringBefore(node.getLabel(), StringUtils.LINEBREAK_REGEX);
+        }
+    }
+
+    public static String substringBefore(String str, Pattern end) {
+        Matcher m = end.matcher(str);
+        if (m.find()) {
+            return m.group(0);
+        } else {
+            return str;
+        }
+    }
+}

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/LineGraphExporter.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/LineGraphExporter.java
@@ -41,17 +41,10 @@ public class LineGraphExporter implements Exporter {
             output.println(LineGraphConstants.LG_NODE + " " + node.getID() + " " + format.getNodeFormat().toLabel(node));
         });
 
-        format.forEachUniqueEdge(diffTree, (edges) -> {
-            output.print(Functjonal.unwords(LineGraphConstants.LG_EDGE, edges.get(0).from().getID(), edges.get(0).to().getID(), ""));
-
-            for (var edge : edges) {
-                output.print(edge.style().lineGraphType());
-            }
-
-            for (var edge : edges) {
-                output.print(format.getEdgeFormat().labelOf(edge));
-            }
-
+        format.forEachEdge(diffTree, edge -> {
+            output.print(Functjonal.unwords(LineGraphConstants.LG_EDGE, edge.from().getID(), edge.to().getID(), ""));
+            output.print(edge.style().lineGraphType());
+            output.print(format.getEdgeFormat().labelOf(edge));
             output.println();
         });
     }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/StyledEdge.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/StyledEdge.java
@@ -10,9 +10,10 @@ import org.variantsync.diffdetective.variation.diff.DiffNode;
  * should be encoded into {@code style}.
  */
 public record StyledEdge(DiffNode from, DiffNode to, Style style) {
-    public record Style(char lineGraphType, String tikzStyle) {
+    public record Style(String lineGraphType, String tikzStyle) {
     }
 
-    public static final Style BEFORE = new Style('b', "before");
-    public static final Style AFTER = new Style('a', "after");
+    public static final Style BEFORE = new Style("b", "before");
+    public static final Style AFTER = new Style("a", "after");
+    public static final Style ALWAYS = new Style("ba", "always");
 }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/TikzExporter.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/TikzExporter.java
@@ -66,23 +66,11 @@ public final class TikzExporter implements Exporter {
 
         // Add all TikZ nodes positioned at the Graphviz coordinates.
         format.forEachNode(diffTree, (node) -> {
-            String escapedLabel =
-                format
-                    .getNodeFormat()
-                    .toMultilineLabel(node)
-                    .stream()
-                    .map(LaTeX::escape)
-                    .collect(Collectors
-                    .joining(" \\\\ "));
-
             output.format("%n\t\\node[%s, %s] (node_%s) at (%s) {};%n",
                 node.isArtifact() ? "artifact" : "annotation",
                 node.getDiffType().toString().toLowerCase(Locale.ROOT),
                 node.getID(),
                 node.getID());
-            output.format("\t\\node[textbox] at (%s) {%s};%n",
-                node.getID(),
-                escapedLabel);
         });
 
         // Add all TikZ edges positioned.
@@ -94,6 +82,22 @@ public final class TikzExporter implements Exporter {
                 edge.to().getID());
         });
         output.println(";");
+
+        // Draw node labels. We do this last so that they are on top of edges and nodes.
+        format.forEachNode(diffTree, (node) -> {
+            String escapedLabel =
+                    format
+                            .getNodeFormat()
+                            .toMultilineLabel(node)
+                            .stream()
+                            .map(LaTeX::escape)
+                            .collect(Collectors
+                                    .joining(" \\\\ "));
+
+            output.format("\t\\node[textbox] at (%s) {%s};%n",
+                    node.getID(),
+                    escapedLabel);
+        });
 
         // Finish the TikZ picture.
         output.println("\\end{tikzpicture}");

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/TikzExporter.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/TikzExporter.java
@@ -66,12 +66,13 @@ public final class TikzExporter implements Exporter {
 
         // Add all TikZ nodes positioned at the Graphviz coordinates.
         format.forEachNode(diffTree, (node) -> {
-            output.format("%n\t\\node[%s, %s] (node_%s) at (%s) {};%n",
+            output.format("%n\t\\node[%s, %s] (node_%s) at (%s) {};",
                 node.isArtifact() ? "artifact" : "annotation",
                 node.getDiffType().toString().toLowerCase(Locale.ROOT),
                 node.getID(),
                 node.getID());
         });
+        output.println("");
 
         // Add all TikZ edges positioned.
         output.format("%n\t\\draw[vtdarrow]");
@@ -82,6 +83,7 @@ public final class TikzExporter implements Exporter {
                 edge.to().getID());
         });
         output.println(";");
+        output.println("");
 
         // Draw node labels. We do this last so that they are on top of edges and nodes.
         format.forEachNode(diffTree, (node) -> {

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/TikzExporter.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/TikzExporter.java
@@ -82,8 +82,9 @@ public final class TikzExporter implements Exporter {
                 edge.style().tikzStyle(),
                 edge.to().getID());
         });
-        output.println(";");
-        output.println("");
+        output.println();
+        output.format("%n\t;");
+        output.println();
 
         // Draw node labels. We do this last so that they are on top of edges and nodes.
         format.forEachNode(diffTree, (node) -> {

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/DiffNodeLabelFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/DiffNodeLabelFormat.java
@@ -12,6 +12,7 @@ import org.variantsync.functjonal.Pair;
  * Reads and writes {@link DiffNode DiffNodes} from and to line graph.
  * @author Paul Bittner, Kevin Jedelhauser
  */
+@FunctionalInterface
 public interface DiffNodeLabelFormat extends LinegraphFormat {
 	/**
 	 * Converts a label of line graph into a {@link DiffNode}.


### PR DESCRIPTION
Hi @ibbem,

these are some tweaks I made to the tikz exporter a few months ago, when I used it to generate graphics for my presentation.

If I remember correctly, the major change here was to treat parallel edges as one unchanged edge during the export. Otherwise, the two parallel edges were drawn on top of each other and only one of them remained visible.

This PR also adds a new main method to have a small program that turns text-diffs to tikz. It might be a good idea to extend that main method later with the `Show` facilities from PR #72 . Then, we could have a small utility program that loads a given text diff in our view which lets you choose a proper layout and manually rearrange nodes, and then export to tikz.