### PR TITLE
Bugfix Regarding Empty Lines in Diffs

### DIFF
--- a/src/main/java/org/variantsync/diffdetective/variation/diff/DiffType.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/DiffType.java
@@ -105,17 +105,15 @@ public enum DiffType {
     /**
      * Parses the diff type from a line taken from a text-based diff.
      * @param line A line in a patch.
-     * @return The type of edit of <code>line</code> or null if its an invalid diff line.
+     * @return The type of edit of <code>line</code> or null if the line is empty.
      */
     public static DiffType ofDiffLine(String line) {
         if (line.startsWith(ADD.symbol)) {
             return ADD;
         } else if (line.startsWith(REM.symbol)) {
             return REM;
-        } else if (line.startsWith(NON.symbol)) {
-            return NON;
         } else {
-            return null;
+            return NON;
         }
     }
 

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/parse/DiffTreeParser.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/parse/DiffTreeParser.java
@@ -170,10 +170,11 @@ public class DiffTreeParser {
             String line = fullDiff.readLine();
             if (line == null) {
                 return null;
-            } else if (line.length() == 0) {
-                return new DiffLine(null, "");
             } else {
-                return new DiffLine(DiffType.ofDiffLine(line), line.substring(1));
+                return new DiffLine(
+                        DiffType.ofDiffLine(line),
+                        line.isEmpty() ? line : line.substring(1)
+                );
             }
         });
     }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/parse/DiffTreeParser.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/parse/DiffTreeParser.java
@@ -263,18 +263,18 @@ public class DiffTreeParser {
         while ((currentDiffLine = lines.get()) != null) {
             final String currentLine = currentDiffLine.content();
 
-            // Ignore line if it is empty.
-            if (ignoreEmptyLines && currentLine.isBlank()) {
-                // discard empty lines
-                continue;
-            }
-
             final DiffType diffType = currentDiffLine.diffType();
             if (diffType == null) {
                 throw new DiffParseException(DiffError.INVALID_DIFF, lineNumber.add(1));
             }
 
             lineNumber = lineNumber.add(1, diffType);
+
+            // Ignore line if it is empty.
+            if (ignoreEmptyLines && currentLine.isBlank()) {
+                // discard empty lines
+                continue;
+            }
 
             // Do beforeLine and afterLine represent the same unchanged diff line?
             isNon = diffType == DiffType.NON &&


### PR DESCRIPTION
- Treat empty lines as unchanged lines.
- The parser did not increase the line number counter when it skipped an empty line. This resulted in wrong line numbers for all subsequently parsed lines.