### PR TITLE
Run CI regardless of branch

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ "main", "develop" ]
   pull_request:
-    branches: [ "main", "develop" ]
+    branches:
 
 jobs:
   build:


### PR DESCRIPTION
This seems to be appropriate to detect issues like https://github.com/VariantSync/DiffDetective/pull/80#issuecomment-1473357907 more quickly.