### PR TITLE
Use identity instead of equality for comparing `DiffNode`s

### DIFF
--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfAddToPC.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfAddToPC.java
@@ -24,7 +24,7 @@ public final class FeatureContextOfAddToPC implements FeatureContextReverseEngin
         final LineRange diffLines = codeNode.getLinesInDiff();
 
         return new PatternMatch<>(this,
-                diffLines.getFromInclusive(), diffLines.getToExclusive(), fm
+                diffLines.fromInclusive(), diffLines.toExclusive(), fm
         );
     }
 

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfAddWithMapping.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfAddWithMapping.java
@@ -24,8 +24,8 @@ public final class FeatureContextOfAddWithMapping implements FeatureContextRever
         final LineRange diffLines = codeNode.getLinesInDiff();
 
         return new PatternMatch<>(this,
-                diffLines.getFromInclusive(),
-                diffLines.getToExclusive(), fm
+                diffLines.fromInclusive(),
+                diffLines.toExclusive(), fm
         );
     }
 

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfGeneralization.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfGeneralization.java
@@ -19,7 +19,7 @@ public final class FeatureContextOfGeneralization implements FeatureContextRever
     public PatternMatch<DiffNode> createMatch(DiffNode codeNode) {
         final LineRange diffLines = codeNode.getLinesInDiff();
         return new PatternMatch<>(this,
-                diffLines.getFromInclusive(), diffLines.getToExclusive()
+                diffLines.fromInclusive(), diffLines.toExclusive()
         );
     }
 

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfReconfiguration.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfReconfiguration.java
@@ -19,7 +19,7 @@ public final class FeatureContextOfReconfiguration implements FeatureContextReve
     public PatternMatch<DiffNode> createMatch(DiffNode codeNode) {
         final LineRange diffLines = codeNode.getLinesInDiff();
         return new PatternMatch<>(this,
-                diffLines.getFromInclusive(), diffLines.getToExclusive()
+                diffLines.fromInclusive(), diffLines.toExclusive()
         );
     }
 

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfRefactoring.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfRefactoring.java
@@ -19,7 +19,7 @@ public final class FeatureContextOfRefactoring implements FeatureContextReverseE
     public PatternMatch<DiffNode> createMatch(DiffNode codeNode) {
         final LineRange diffLines = codeNode.getLinesInDiff();
         return new PatternMatch<>(this,
-                diffLines.getFromInclusive(), diffLines.getToExclusive()
+                diffLines.fromInclusive(), diffLines.toExclusive()
         );
     }
 

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfRemFromPC.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfRemFromPC.java
@@ -24,7 +24,7 @@ public final class FeatureContextOfRemFromPC implements FeatureContextReverseEng
         final LineRange diffLines = codeNode.getLinesInDiff();
 
         return new PatternMatch<>(this,
-                diffLines.getFromInclusive(), diffLines.getToExclusive(), fm
+                diffLines.fromInclusive(), diffLines.toExclusive(), fm
         );
     }
 

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfRemWithMapping.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfRemWithMapping.java
@@ -24,7 +24,7 @@ public final class FeatureContextOfRemWithMapping implements FeatureContextRever
         final LineRange diffLines = codeNode.getLinesInDiff();
 
         return new PatternMatch<>(this,
-                diffLines.getFromInclusive(), diffLines.getToExclusive(), fm
+                diffLines.fromInclusive(), diffLines.toExclusive(), fm
         );
     }
 

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfSpecialization.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfSpecialization.java
@@ -19,7 +19,7 @@ public final class FeatureContextOfSpecialization implements FeatureContextRever
     public PatternMatch<DiffNode> createMatch(DiffNode codeNode) {
         final LineRange diffLines = codeNode.getLinesInDiff();
         return new PatternMatch<>(this,
-                diffLines.getFromInclusive(), diffLines.getToExclusive()
+                diffLines.fromInclusive(), diffLines.toExclusive()
         );
     }
 

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfUntouched.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfUntouched.java
@@ -19,7 +19,7 @@ public class FeatureContextOfUntouched implements FeatureContextReverseEngineeri
     public PatternMatch<DiffNode> createMatch(DiffNode codeNode) {
         final LineRange diffLines = codeNode.getLinesInDiff();
         return new PatternMatch<>(this,
-                diffLines.getFromInclusive(), diffLines.getToExclusive()
+                diffLines.fromInclusive(), diffLines.toExclusive()
         );
     }
 

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/semantic/AddIfdefElif.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/semantic/AddIfdefElif.java
@@ -49,7 +49,7 @@ class AddIfdefElif extends SemanticPattern {
 
             final LineRange diffLines = annotationNode.getLinesInDiff();
             return Optional.of(new PatternMatch<>(this,
-                    diffLines.getFromInclusive(), diffLines.getToExclusive(),
+                    diffLines.fromInclusive(), diffLines.toExclusive(),
                     mappings.toArray(new Node[0])
             ));
         }

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/semantic/AddIfdefElse.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/semantic/AddIfdefElse.java
@@ -56,7 +56,7 @@ class AddIfdefElse extends SemanticPattern {
             }
 
             return Optional.of(new PatternMatch<>(this,
-                    annotationNode.getLinesInDiff().getFromInclusive(), elseNode.getLinesInDiff().getToExclusive(),
+                    annotationNode.getLinesInDiff().fromInclusive(), elseNode.getLinesInDiff().toExclusive(),
                     annotationNode.getFeatureMapping(AFTER)
             ));
         }

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/semantic/AddIfdefWrapElse.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/semantic/AddIfdefWrapElse.java
@@ -55,7 +55,7 @@ class AddIfdefWrapElse extends SemanticPattern {
             }
 
             return Optional.of(new PatternMatch<>(this,
-                    annotationNode.getLinesInDiff().getFromInclusive(), elseNode.getLinesInDiff().getToExclusive(),
+                    annotationNode.getLinesInDiff().fromInclusive(), elseNode.getLinesInDiff().toExclusive(),
                     annotationNode.getFeatureMapping(AFTER)
             ));
         }

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/semantic/AddIfdefWrapThen.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/semantic/AddIfdefWrapThen.java
@@ -56,7 +56,7 @@ class AddIfdefWrapThen extends SemanticPattern {
             }
 
             return Optional.of(new PatternMatch<>(this,
-                    annotationNode.getLinesInDiff().getFromInclusive(), elseNode.getLinesInDiff().getToExclusive(),
+                    annotationNode.getLinesInDiff().fromInclusive(), elseNode.getLinesInDiff().toExclusive(),
                     annotationNode.getFeatureMapping(AFTER)
             ));
         }

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/semantic/MoveElse.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/semantic/MoveElse.java
@@ -48,7 +48,7 @@ class MoveElse extends SemanticPattern {
             }
 
             return Optional.of(new PatternMatch<>(this,
-                    annotationNode.getLinesInDiff().getFromInclusive(), removedElse.getLinesInDiff().getToExclusive()
+                    annotationNode.getLinesInDiff().fromInclusive(), removedElse.getLinesInDiff().toExclusive()
             ));
         }
 

--- a/src/main/java/org/variantsync/diffdetective/show/Show.java
+++ b/src/main/java/org/variantsync/diffdetective/show/Show.java
@@ -39,8 +39,8 @@ public class Show {
     public static GameEngine baddiff(final BadVDiff badVDiff, final String title) {
         final DiffTree d = badVDiff.diff().toDiffTree(
             v -> {
-                int from = v.getLineRange().getFromInclusive();
-                int to = v.getLineRange().getToExclusive();
+                int from = v.getLineRange().fromInclusive();
+                int to = v.getLineRange().toExclusive();
 
                 return new DiffNode(
                         badVDiff.coloring().get(v),

--- a/src/main/java/org/variantsync/diffdetective/util/LineRange.java
+++ b/src/main/java/org/variantsync/diffdetective/util/LineRange.java
@@ -3,17 +3,15 @@ package org.variantsync.diffdetective.util;
 /**
  * Class to hold a range of line numbers.
  * Mainly used to locate code snippets in source code files and textual diffs.
+ * @param fromInclusive The starting line number of this range. This number is included within the range.
+ * @param toExclusive The ending line number of this range. This number is excluded from the range
+ *                    (i.e., it points to the line right after the last line).
  * @author Paul Bittner
  */
-public class LineRange {
-    private final int fromInclusive; // including
-    private final int toExclusive; // excluding
-
-    private LineRange(int fromInclusive, int toExclusive) {
-        this.fromInclusive = fromInclusive;
-        this.toExclusive = toExclusive;
-    }
-
+public record LineRange(
+        int fromInclusive,
+        int toExclusive
+) {
     /**
      * Creates an invalid range that does not represent a valid range of line numbers in a text file.
      */
@@ -46,26 +44,6 @@ public class LineRange {
     public static LineRange FromInclToIncl(int fromInclusive, int toInclusive) {
         return new LineRange(fromInclusive, toInclusive + 1);
     }
-
-    /**
-     * Returns the starting line number of this range.
-     * This number is included within the range.
-     */
-    public int getFromInclusive() {
-        return fromInclusive;
-    }
-
-    /**
-     * Returns the ending line number of this range.
-     * This number is excluded from the range (i.e., it points to the line right after the last line).
-     */
-    public int getToExclusive() {
-        return toExclusive;
-    }
-
-//    public int getToInclusive() {
-//        return toExclusive;
-//    }
 
 
     @Override

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/DiffNode.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/DiffNode.java
@@ -510,8 +510,8 @@ public class DiffNode implements HasNodeType {
      * the edit.
      */
     public void setLinesAtTime(LineRange lineRange, Time time) {
-        from = from.withLineNumberAtTime(lineRange.getFromInclusive(), time);
-        to = to.withLineNumberAtTime(lineRange.getToExclusive(), time);
+        from = from.withLineNumberAtTime(lineRange.fromInclusive(), time);
+        to = to.withLineNumberAtTime(lineRange.toExclusive(), time);
     }
 
     /**
@@ -776,8 +776,8 @@ public class DiffNode implements HasNodeType {
      * to itself. Acts on only the given node and does not perform recursive translations.
      */
     public static <T extends VariationNode<T>> DiffNode unchangedFlat(T variationNode) {
-        int from = variationNode.getLineRange().getFromInclusive();
-        int to = variationNode.getLineRange().getToExclusive();
+        int from = variationNode.getLineRange().fromInclusive();
+        int to = variationNode.getLineRange().toExclusive();
 
         return new DiffNode(
                 DiffType.NON,

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/DiffTree.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/DiffTree.java
@@ -437,6 +437,14 @@ public class DiffTree {
         return ConsistencyResult.Success();
     }
 
+    /**
+     * Returns true if this {@code DiffTree} is exactly equal to {@code other}.
+     * This check uses equality checks instead of identity.
+     */
+    public boolean isSameAs(DiffTree other) {
+        return this.getRoot().isSameAs(other.getRoot());
+    }
+
     @Override
     public String toString() {
         return "DiffTree of " + source;

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/DiffTree.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/DiffTree.java
@@ -359,7 +359,7 @@ public class DiffTree {
             ALL_PATHS_END_AT_ROOT,
             NOT_ALL_PATHS_END_AT_ROOT
         }
-        private final Map<Integer, VisitStatus> cache = new HashMap<>();
+        private final Map<DiffNode, VisitStatus> cache = new HashMap<>();
         private final DiffNode root;
 
         private AllPathsEndAtRoot(final DiffNode root) {
@@ -375,11 +375,10 @@ public class DiffTree {
                 return true;
             }
 
-            final int id = d.getID();
-            return switch (cache.getOrDefault(id, VisitStatus.STRANGER)) {
+            return switch (cache.getOrDefault(d, VisitStatus.STRANGER)) {
                 case STRANGER -> {
                     // The stranger is now known.
-                    cache.putIfAbsent(id, VisitStatus.VISITED);
+                    cache.putIfAbsent(d, VisitStatus.VISITED);
 
                     final DiffNode b = d.getParent(BEFORE);
                     final DiffNode a = d.getParent(AFTER);
@@ -397,7 +396,7 @@ public class DiffTree {
                     }
 
                     // Now we also know the result for the stranger.
-                    cache.put(id, result ? VisitStatus.ALL_PATHS_END_AT_ROOT : VisitStatus.NOT_ALL_PATHS_END_AT_ROOT);
+                    cache.put(d, result ? VisitStatus.ALL_PATHS_END_AT_ROOT : VisitStatus.NOT_ALL_PATHS_END_AT_ROOT);
                     yield result;
                 }
                 // We detected a cycle because we visited a node but did not determine its value yet!

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/Projection.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/Projection.java
@@ -18,12 +18,6 @@ import org.variantsync.functjonal.list.FilteredMappedListView;
  *
  * <p>This class has to be instantiated using {@link DiffNode#projection}.
  *
- * <p>Implementation note: It's ensured that identity can be checked using {@code ==}. This
- * prevents unexpected behaviour if some code uses {@code ==} instead of {@link isSameAs} as
- * documented in {@link VariationNode}. Although this is currently guaranteed by all
- * implementations of {@link VariationNode} it should still be considered a bug if {@code ==} is
- * used to check for identity ({@code null} checks are still allowed).
- *
  * @see DiffNode#projection
  */
 public class Projection extends VariationNode<Projection> {
@@ -147,23 +141,5 @@ public class Projection extends VariationNode<Projection> {
     @Override
     public int getID() {
         return getBackingNode().getID();
-    }
-
-    @Override
-    public boolean isSameAs(Projection other) {
-        if (other != null && getClass() == other.getClass()) {
-            Projection otherProjection = (Projection) other;
-            return time.equals(otherProjection.time) && getBackingNode() == otherProjection.getBackingNode();
-        } else {
-            return false;
-        }
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Projection projection = (Projection) o;
-        return time.equals(projection.time) && getBackingNode().equals(projection.getBackingNode());
     }
 };

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/graph/FormalDiffGraph.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/graph/FormalDiffGraph.java
@@ -68,20 +68,5 @@ public record FormalDiffGraph(
 
         return b.toString();
     }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        final FormalDiffGraph graph = (FormalDiffGraph) o;
-
-        return     nodes.equals(graph.nodes)
-                && edges.equals(graph.edges);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(nodes, edges);
-    }
 }
 

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/traverse/DiffTreeTraversal.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/traverse/DiffTreeTraversal.java
@@ -22,7 +22,7 @@ import java.util.function.Consumer;
  * @author Paul Bittner
  */
 public class DiffTreeTraversal {
-    private final Set<Integer> visited;
+    private final Set<DiffNode> visited;
     private final DiffTreeVisitor visitor;
 
     private DiffTreeTraversal(final DiffTreeVisitor visitor) {
@@ -86,6 +86,6 @@ public class DiffTreeTraversal {
      *         False if the node was already marked visited.
      */
     private boolean markAsVisited(final DiffNode node) {
-        return visited.add(node.getID());
+        return visited.add(node);
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/variation/tree/VariationTreeNode.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/tree/VariationTreeNode.java
@@ -358,32 +358,6 @@ public class VariationTreeNode extends VariationNode<VariationTreeNode> {
     }
 
     @Override
-    public boolean isSameAs(VariationTreeNode other) {
-        return this == other;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        var other = (VariationTreeNode) o;
-        return nodeType == other.nodeType && lineRange.equals(other.lineRange) && Objects.equals(featureMapping, other.featureMapping) && label.equals(other.label);
-    }
-
-    /**
-     * Compute a hash using all available attributes.
-     *
-     * <p>This implementation doesn't strictly adhere to the contract required by {@code Object},
-     * because some attributes (for example the line numbers) can be changed during the lifetime of
-     * a node. So when using something like a {@code HashSet} the user of this class has to be
-     * careful with any modifications of attributes.
-     */
-    @Override
-    public int hashCode() {
-        return Objects.hash(nodeType, lineRange, featureMapping, label);
-    }
-
-    @Override
     public String toString() {
         String s;
         if (isArtifact()) {

--- a/src/main/java/org/variantsync/diffdetective/variation/tree/VariationTreeNode.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/tree/VariationTreeNode.java
@@ -290,7 +290,7 @@ public class VariationTreeNode extends VariationNode<VariationTreeNode> {
     @Override
     public int getID() {
         // Add one to ensure invalid (negative) line numbers don't cause issues.
-        final int lineNumber = 1 + getLineRange().getFromInclusive();
+        final int lineNumber = 1 + getLineRange().fromInclusive();
 
         final int usedBitCount = DiffType.getRequiredBitCount() + NodeType.getRequiredBitCount();
         Assert.assertTrue((lineNumber << usedBitCount) >> usedBitCount == lineNumber);

--- a/src/test/java/BadVDiffTest.java
+++ b/src/test/java/BadVDiffTest.java
@@ -28,18 +28,16 @@ public class BadVDiffTest {
         Logger.debug("Testing " + testfile);
 
         final DiffTree initialVDiff = DiffTree.fromFile(testfile, new DiffTreeParseOptions(false, false));
-        final FormalDiffGraph initialVDiffAsGraph = FormalDiffGraph.fromDiffTree(initialVDiff);
-        Logger.debug("Initial:" + StringUtils.LINEBREAK + initialVDiffAsGraph);
+        Logger.debug("Initial:" + StringUtils.LINEBREAK + initialVDiff);
         initialVDiff.assertConsistency();
 
         final BadVDiff badDiff = BadVDiff.fromGood(initialVDiff);
         Logger.debug("Bad:" + StringUtils.LINEBREAK + badDiff.prettyPrint());
 
         final DiffTree goodDiff = badDiff.toGood();
-        final FormalDiffGraph goodDiffAsGraph = FormalDiffGraph.fromDiffTree(goodDiff);
-        Logger.debug("Good:" + StringUtils.LINEBREAK + goodDiffAsGraph);
+        Logger.debug("Good:" + StringUtils.LINEBREAK + goodDiff);
         goodDiff.assertConsistency();
 
-        Assertions.assertEquals(initialVDiffAsGraph, goodDiffAsGraph);
+        Assertions.assertTrue(initialVDiff.isSameAs(goodDiff));
     }
 }


### PR DESCRIPTION
This change has the following benefits:
- It's easier to reason about algorithms on `DiffTree`s as no two distinct nodes will ever be equal. For example, it lets us refactor `LineRange` to a record (2f73d29ff0b26d1fe6458956023da3e1e63f0691) without breaking `BadVDiffs` which relied on the identity checks (instead of equality) of `LineRange`. In the case of `LineRange` identity based equality was actually very odd.
- We reduce the reliance on the uniqueness of `DiffNode.getID` and  `DiffNode.getID` in general. My goal is to get rid of `DiffNode.getID` completely and only compute it when exporting to formats which require such IDs (e.g. line graphs).
- I think there should be a performance improvement (not tested).

In the future, we might need some equality checks for our graphs and trees (e.g. something like what `FormalDiffGraph` is used for). There are different ways to characterize `DiffTree` equality though. For example, the line numbers in the diff are not unique (different diffs can be equivalent), so should they be taken into account? Thus, not defining a standard `equals` based on equality is a good thing.