### PR TITLE
fix: diffs are now analyzed if they match a filter before or after a change

### DIFF
--- a/src/main/java/org/variantsync/diffdetective/diff/git/DiffFilter.java
+++ b/src/main/java/org/variantsync/diffdetective/diff/git/DiffFilter.java
@@ -258,7 +258,7 @@ public class DiffFilter {
      */
     public boolean filter(DiffEntry diffEntry) {
         if (!allowedPaths.isEmpty() &&
-                !(isAllowedPath(diffEntry.getOldPath()) && isAllowedPath(diffEntry.getNewPath())))
+                !(isAllowedPath(diffEntry.getOldPath()) || isAllowedPath(diffEntry.getNewPath())))
         {
             return false;
         }
@@ -273,7 +273,7 @@ public class DiffFilter {
             return false;
         }
         if (!allowedFileExtensions.isEmpty() &&
-                !(hasAllowedExtension(diffEntry.getOldPath()) && hasAllowedExtension(diffEntry.getNewPath())))
+                !(hasAllowedExtension(diffEntry.getOldPath()) || hasAllowedExtension(diffEntry.getNewPath())))
         {
             return false;
         }


### PR DESCRIPTION
# Issue description
DiffDetective filters diffs before analysis based on a number of filter criterion that can be configured by a user. Two of these possible filters are a filter by file path and a filter by file extension. The issue with these two filters is that they expect the file described in the diff to match the filter at `Time.BEFORE` and `Time.AFTER` (i.e., before and after the changes in the diffs have been applied).  However, this will filter diffs of all added, all removed, and some renamed/moved files.

Here, I differentiate between _inclusion_ filters (i.e., include if at least one matches) and _exclusion_ filters (i.e., exclude if at least one matches). The two changed filters are inclusion filters and I argue that these filters should apply if they match either before or after such a file level change, even for renamed or moved files. 

# Example
Assume that there is a file extension filter `f` that only allows C files (i.e., extension `.c`). If a new file `main.c` is added by the diff, the diff is incorrectly filtered because the filename _before_ the edit is `null` as the file did not exist yet.   

> The same applies for deleted files, because their file name changes to `null`.

# Fix
I changed the logical operators for the two filters from `&&` to `||`. 

I have _not_ changed the logic for the two filters that block certain paths or file extensions. These two blocking filters are exclusion filters and already work as intended.
