### PR TITLE
Fix scheduled task iteration

### DIFF
--- a/src/main/java/org/variantsync/diffdetective/parallel/ScheduledTasksIterator.java
+++ b/src/main/java/org/variantsync/diffdetective/parallel/ScheduledTasksIterator.java
@@ -70,7 +70,7 @@ public class ScheduledTasksIterator<T> implements Iterator<T>, AutoCloseable {
 
     /** Stops all scheduled tasks and releases the used thread resources. */
     @Override
-    public void close() throws Exception {
+    public void close() {
         threadPool.shutdown();
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/parallel/ScheduledTasksIterator.java
+++ b/src/main/java/org/variantsync/diffdetective/parallel/ScheduledTasksIterator.java
@@ -9,8 +9,9 @@ import java.util.concurrent.*;
  * The results of the given tasks can be received in the correct order using {@link next}. That
  * means the {@link next} method is deterministic if all tasks are deterministic.
  *
- * <p>No extra thread for scheduling is used so new tasks are only scheduled if {@link next} is
- * called.
+ * <p>Upon creation of a ScheduledTasksIterator, all given tasks are scheduled for execution. However, the results of these
+ * tasks become available in the same order as the tasks have been provided. This means, that the iterator will block
+ * until the result of the next task is available, even if all other remaining tasks are complete.
  */
 public class ScheduledTasksIterator<T> implements Iterator<T>, AutoCloseable {
     private final Iterator<? extends Callable<T>> remainingTasks;
@@ -20,7 +21,7 @@ public class ScheduledTasksIterator<T> implements Iterator<T>, AutoCloseable {
     /**
      * Starts scheduling {@code tasks} in {@code nThreads} other threads.
      * The results of these tasks can be retrieved by calling {@link next}. The order of these
-     * results not deterministic and can't be assumed to be the same as in {@code tasks}.
+     * results is deterministic and is the same as the order of the provided {@code tasks}.
      *
      * @param tasks the tasks which will be executed in other threads
      * @param nThreads the number of threads which work on {@code tasks} in parallel
@@ -29,8 +30,8 @@ public class ScheduledTasksIterator<T> implements Iterator<T>, AutoCloseable {
         this.remainingTasks = tasks;
         this.futures = new LinkedList<>();
         this.threadPool = Executors.newFixedThreadPool(nThreads);
-        for (int i = 0; i < nThreads; i++) {
-            scheduleNext();
+        while (this.remainingTasks.hasNext()) {
+            futures.add(threadPool.submit(remainingTasks.next()));
         }
     }
 
@@ -42,16 +43,6 @@ public class ScheduledTasksIterator<T> implements Iterator<T>, AutoCloseable {
      */
     public ScheduledTasksIterator(final Iterable<? extends Callable<T>> tasks, final int nThreads) {
         this(tasks.iterator(), nThreads);
-    }
-
-    /**
-     * Schedule the next task on the thread pool and adds the result future to the {@code futures}
-     * queue.
-     */
-    private synchronized void scheduleNext() {
-        if (this.remainingTasks.hasNext()) {
-            futures.add(threadPool.submit(remainingTasks.next()));
-        }
     }
 
     @Override
@@ -70,7 +61,6 @@ public class ScheduledTasksIterator<T> implements Iterator<T>, AutoCloseable {
      */
     @Override
     public T next() {
-        scheduleNext();
         try {
             return futures.removeFirst().get();
         } catch (final InterruptedException | ExecutionException e) {


### PR DESCRIPTION
# Description
ScheduledTasksIterator contained a bottleneck in its scheduling that hat a severe effect on the runtime performance, if some tasks take considerably longer than others. Before the fix, the iterator would only schedule at most `nThreads` tasks in its internal thread pool. Upon consumption of the iterator, a new task was only scheduled, if the next result became available (i.e., a call to `next()` returned a result). This creates a bottleneck, if the iterator has to block upon a `next()` call for a long task. This potentially leads to a high number of idle threads.

With the fix, all tasks are scheduled upon creation of the iterator and their execution is managed by the thread pool with an internal queue. This way, all threads are busy until all scheduled tasks are done. The order of results is still managed by the list of futures, which guarantees that order of results is the same as the order of the given tasks.  

# Example
Consider an iterator using a thread pool with 3 threads and 6 tasks to complete. Upon instantiation, the iterator would schedule the firsts 3 tasks for execution. This results in the following state for the tasks:
```
- task1: ONGOING
- task2: ONGOING
- task3: ONGOING
- task4: NOT SCHEDULED
- task5: NOT SCHEDULED
- task6: NOT SCHEDULED
```
and for the threads:
```
- thread1: PROCESSING task1
- thread2: PROCESSING task2
- thread3: PROCESSING task3
```

Now, assume that the iterator is being consumed and a bit of time passed. `task2` and `task3` are done; `task1` is ongoing. The iterator blocks upon the first `next()` call until the result is ready. No new tasks are scheduled. The state would now look as follows:
```
- task1: ONGOING
- task2: DONE
- task3: DONE
- task4: NOT SCHEDULED
- task5: NOT SCHEDULED
- task6: NOT SCHEDULED
```
and for the threads:
```
- thread1: PROCESSING task1
- thread2: IDLE
- thread3: IDLE
```

With the fix, all tasks are scheduled immediately and sequentially submitted to free threads by the thread pool. The initial state now looks like this:
 ```
 - task1: ONGOING
 - task2: ONGOING
 - task3: ONGOING
 - task4: SCHEDULED
 - task5: SCHEDULED
 - task6: SCHEDULED
 ```
 and for the threads:
 ```
 - thread1: PROCESSING task1
 - thread2: PROCESSING task2
 - thread3: PROCESSING task3
 ```
And the second state with the same conditions as above looks like this:
```
- task1: ONGOING
- task2: DONE
- task3: DONE
- task4: ONGOING
- task5: ONGOING
- task6: NOT SCHEDULED
```
and for the threads:
```
- thread1: PROCESSING task1
- thread2: PROCESSING task4
- thread3: PROCESSING task5
```