### PR TITLE
Generalize variation trees to support nested variation trees

### DIFF
--- a/src/main/java/org/variantsync/diffdetective/analysis/Analysis.java
+++ b/src/main/java/org/variantsync/diffdetective/analysis/Analysis.java
@@ -25,6 +25,7 @@ import org.variantsync.diffdetective.parallel.ScheduledTasksIterator;
 import org.variantsync.diffdetective.util.Clock;
 import org.variantsync.diffdetective.util.Diagnostics;
 import org.variantsync.diffdetective.util.InvocationCounter;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.functjonal.iteration.ClusteredIterator;
 import org.variantsync.functjonal.iteration.MappedIterator;
@@ -64,7 +65,7 @@ public class Analysis {
     protected RevCommit currentCommit;
     protected CommitDiff currentCommitDiff;
     protected PatchDiff currentPatch;
-    protected DiffTree currentDiffTree;
+    protected DiffTree<DiffLinesLabel> currentDiffTree;
 
     protected final Path outputDir;
     protected Path outputFile;
@@ -106,7 +107,7 @@ public class Analysis {
      * The currently processed patch.
      * Valid only during {@link Hooks#analyzeDiffTree}.
      */
-    public DiffTree getCurrentDiffTree() {
+    public DiffTree<DiffLinesLabel> getCurrentDiffTree() {
         return currentDiffTree;
     }
 

--- a/src/main/java/org/variantsync/diffdetective/analysis/EditClassOccurenceAnalysis.java
+++ b/src/main/java/org/variantsync/diffdetective/analysis/EditClassOccurenceAnalysis.java
@@ -27,7 +27,7 @@ public class EditClassOccurenceAnalysis implements Analysis.Hooks {
 
     @Override
     public void initializeResults(Analysis analysis) {
-        analysis.append(EditClassCount.KEY, new EditClassCount());
+        analysis.append(EditClassCount.KEY, new EditClassCount(ProposedEditClasses.Instance));
     }
 
     @Override

--- a/src/main/java/org/variantsync/diffdetective/analysis/FilterAnalysis.java
+++ b/src/main/java/org/variantsync/diffdetective/analysis/FilterAnalysis.java
@@ -3,20 +3,21 @@ package org.variantsync.diffdetective.analysis;
 import java.util.Arrays;
 
 import org.variantsync.diffdetective.metadata.ExplainedFilterSummary;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.filter.ExplainedFilter;
 import org.variantsync.diffdetective.variation.diff.filter.TaggedPredicate;
 
 public class FilterAnalysis implements Analysis.Hooks {
-    private ExplainedFilter<DiffTree> treeFilter;
+    private ExplainedFilter<DiffTree<? extends DiffLinesLabel>> treeFilter;
 
-    public FilterAnalysis(ExplainedFilter<DiffTree> treeFilter) {
+    public FilterAnalysis(ExplainedFilter<DiffTree<? extends DiffLinesLabel>> treeFilter) {
         this.treeFilter = treeFilter;
     }
 
     @SafeVarargs
-    public FilterAnalysis(TaggedPredicate<String, DiffTree>... treeFilter) {
-        this.treeFilter = new ExplainedFilter<DiffTree>(Arrays.stream(treeFilter));
+    public FilterAnalysis(TaggedPredicate<String, DiffTree<? extends DiffLinesLabel>>... treeFilter) {
+        this.treeFilter = new ExplainedFilter<>(Arrays.stream(treeFilter));
     }
 
     @Override

--- a/src/main/java/org/variantsync/diffdetective/analysis/LineGraphExportAnalysis.java
+++ b/src/main/java/org/variantsync/diffdetective/analysis/LineGraphExportAnalysis.java
@@ -7,6 +7,7 @@ import org.apache.commons.lang3.NotImplementedException;
 import org.variantsync.diffdetective.analysis.AnalysisResult.ResultKey;
 import org.variantsync.diffdetective.analysis.strategies.AnalysisStrategy;
 import org.variantsync.diffdetective.metadata.Metadata;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.serialize.LineGraphExport;
 import org.variantsync.diffdetective.variation.diff.serialize.LineGraphExportOptions;
 import org.variantsync.functjonal.category.InplaceSemigroup;
@@ -45,10 +46,10 @@ public class LineGraphExportAnalysis implements Analysis.Hooks {
     }
 
     private final AnalysisStrategy analysisStrategy;
-    private final LineGraphExportOptions exportOptions;
+    private final LineGraphExportOptions<? super DiffLinesLabel> exportOptions;
     private OutputStream lineGraphDestination;
 
-    public LineGraphExportAnalysis(final AnalysisStrategy analysisStrategy, final LineGraphExportOptions exportOptions) {
+    public LineGraphExportAnalysis(final AnalysisStrategy analysisStrategy, final LineGraphExportOptions<? super DiffLinesLabel> exportOptions) {
         this.analysisStrategy = analysisStrategy;
         this.exportOptions = exportOptions;
     }

--- a/src/main/java/org/variantsync/diffdetective/analysis/PreprocessingAnalysis.java
+++ b/src/main/java/org/variantsync/diffdetective/analysis/PreprocessingAnalysis.java
@@ -4,15 +4,17 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.variantsync.diffdetective.variation.diff.transform.DiffTreeTransformer;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 
 public class PreprocessingAnalysis implements Analysis.Hooks {
-    private final List<DiffTreeTransformer> preprocessors;
+    private final List<DiffTreeTransformer<DiffLinesLabel>> preprocessors;
 
-    public PreprocessingAnalysis(List<DiffTreeTransformer> preprocessors) {
+    public PreprocessingAnalysis(List<DiffTreeTransformer<DiffLinesLabel>> preprocessors) {
         this.preprocessors = preprocessors;
     }
 
-    public PreprocessingAnalysis(DiffTreeTransformer... preprocessors) {
+    @SafeVarargs
+    public PreprocessingAnalysis(DiffTreeTransformer<DiffLinesLabel>... preprocessors) {
         this.preprocessors = Arrays.asList(preprocessors);
     }
 

--- a/src/main/java/org/variantsync/diffdetective/diff/git/GitDiffer.java
+++ b/src/main/java/org/variantsync/diffdetective/diff/git/GitDiffer.java
@@ -21,6 +21,7 @@ import org.variantsync.diffdetective.diff.result.DiffParseException;
 import org.variantsync.diffdetective.preliminary.GitDiff;
 import org.variantsync.diffdetective.util.Assert;
 import org.variantsync.diffdetective.util.StringUtils;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.parse.DiffTreeParser;
 import org.variantsync.functjonal.iteration.MappedIterator;
@@ -36,7 +37,6 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * This class creates a GitDiff-object from a git repository (Git-object).
@@ -375,7 +375,7 @@ public class GitDiffer {
                         fullDiff += StringUtils.LINEBREAK;
                     }
 
-                    final DiffTree diffTree = DiffTreeParser.createDiffTree(
+                    final DiffTree<DiffLinesLabel> diffTree = DiffTreeParser.createDiffTree(
                             fullDiff,
                             parseOptions.diffTreeParseOptions()
                     );

--- a/src/main/java/org/variantsync/diffdetective/diff/git/PatchDiff.java
+++ b/src/main/java/org/variantsync/diffdetective/diff/git/PatchDiff.java
@@ -2,6 +2,7 @@ package org.variantsync.diffdetective.diff.git;
 
 import org.apache.commons.io.FilenameUtils;
 import org.eclipse.jgit.diff.DiffEntry;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 
 /**
@@ -13,7 +14,7 @@ import org.variantsync.diffdetective.variation.diff.DiffTree;
  */
 public class PatchDiff implements GitPatch {
     private final String fullDiff;
-    private final DiffTree diffTree;
+    private final DiffTree<DiffLinesLabel> diffTree;
 
     /**
      * The commit the patch belongs to.
@@ -38,7 +39,7 @@ public class PatchDiff implements GitPatch {
      * @param diffTree The {@link DiffTree} that describes this patch.
      */
     public PatchDiff(CommitDiff commitDiff, DiffEntry diffEntry, String fullDiff,
-                     DiffTree diffTree) {
+                     DiffTree<DiffLinesLabel> diffTree) {
         this.commitDiff = commitDiff;
         this.changeType = diffEntry.getChangeType();
         this.path = diffEntry.getNewPath();
@@ -91,7 +92,7 @@ public class PatchDiff implements GitPatch {
     /**
      * Returns the DiffTree for this patch.
      */
-    public DiffTree getDiffTree() {
+    public DiffTree<DiffLinesLabel> getDiffTree() {
         return diffTree;
     }
 

--- a/src/main/java/org/variantsync/diffdetective/editclass/EditClass.java
+++ b/src/main/java/org/variantsync/diffdetective/editclass/EditClass.java
@@ -9,7 +9,7 @@ import org.variantsync.diffdetective.variation.diff.DiffType;
  * Abstract edit class according to our ESEC/FSE'22 paper.
  * @author Paul Bittner, Sören Viegener
  */
-public abstract class EditClass extends Pattern<DiffNode> {
+public abstract class EditClass extends Pattern<DiffNode<?>> {
     private final DiffType diffType;
 
     /**
@@ -33,20 +33,20 @@ public abstract class EditClass extends Pattern<DiffNode> {
      * Returns true iff the given node matches this edit class.
      * @param artifactNode Node which has node type ARTIFACT and whose DiffType is the same as {@link getDiffType()}.
      */
-    protected abstract boolean matchesArtifactNode(DiffNode artifactNode);
+    protected abstract boolean matchesArtifactNode(DiffNode<?> artifactNode);
 
     /**
      * Returns true if this edit class matches the given node and is an artifact.
      */
     @Override
-    public final boolean matches(DiffNode node) {
+    public final boolean matches(DiffNode<?> node) {
         return node.isArtifact() && node.diffType == diffType && matchesArtifactNode(node);
     }
 
     /**
      * Returns true iff this edit class matches at leat one node on the given tree.
      */
-    public boolean anyMatch(final DiffTree t) {
+    public boolean anyMatch(final DiffTree<?> t) {
         return t.anyMatch(this::matches);
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/editclass/EditClassCatalogue.java
+++ b/src/main/java/org/variantsync/diffdetective/editclass/EditClassCatalogue.java
@@ -32,7 +32,7 @@ public interface EditClassCatalogue {
      * @param node The node of which to find its edit class.
      * @return Returns the edit class that matches the given node.
      */
-    default EditClass match(DiffNode node)
+    default EditClass match(DiffNode<?> node)
     {
         if (!node.isArtifact()) {
             throw new IllegalArgumentException("Expected an artifact node but got " + node.nodeType + "!");

--- a/src/main/java/org/variantsync/diffdetective/editclass/EditClassCatalogue.java
+++ b/src/main/java/org/variantsync/diffdetective/editclass/EditClassCatalogue.java
@@ -35,7 +35,7 @@ public interface EditClassCatalogue {
     default EditClass match(DiffNode<?> node)
     {
         if (!node.isArtifact()) {
-            throw new IllegalArgumentException("Expected an artifact node but got " + node.nodeType + "!");
+            throw new IllegalArgumentException("Expected an artifact node but got " + node.getNodeType() + "!");
         }
 
         final List<EditClass> classessToCheck = byType().get(node.diffType);

--- a/src/main/java/org/variantsync/diffdetective/editclass/proposed/AddToPC.java
+++ b/src/main/java/org/variantsync/diffdetective/editclass/proposed/AddToPC.java
@@ -1,6 +1,7 @@
 package org.variantsync.diffdetective.editclass.proposed;
 
 import org.variantsync.diffdetective.editclass.EditClass;
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.DiffType;
 
@@ -16,7 +17,7 @@ final class AddToPC extends EditClass {
     }
 
     @Override
-    protected boolean matchesArtifactNode(DiffNode node) {
+    protected boolean matchesArtifactNode(DiffNode<?> node) {
         return !node.getParent(AFTER).isAdd();
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/editclass/proposed/AddWithMapping.java
+++ b/src/main/java/org/variantsync/diffdetective/editclass/proposed/AddWithMapping.java
@@ -16,7 +16,7 @@ final class AddWithMapping extends EditClass {
     }
 
     @Override
-    protected boolean matchesArtifactNode(DiffNode artifactNode) {
+    protected boolean matchesArtifactNode(DiffNode<?> artifactNode) {
         return artifactNode.getParent(AFTER).isAdd();
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/editclass/proposed/Generalization.java
+++ b/src/main/java/org/variantsync/diffdetective/editclass/proposed/Generalization.java
@@ -19,7 +19,7 @@ final class Generalization extends EditClass {
     }
 
     @Override
-    protected boolean matchesArtifactNode(DiffNode artifactNode) {
+    protected boolean matchesArtifactNode(DiffNode<?> artifactNode) {
         final Node pcb = artifactNode.getFeatureMapping(BEFORE);
         final Node pca = artifactNode.getFeatureMapping(AFTER);
         return SAT.implies(pcb, pca) && !SAT.implies(pca, pcb);

--- a/src/main/java/org/variantsync/diffdetective/editclass/proposed/ProposedEditClasses.java
+++ b/src/main/java/org/variantsync/diffdetective/editclass/proposed/ProposedEditClasses.java
@@ -75,7 +75,7 @@ public class ProposedEditClasses implements EditClassCatalogue {
         // Each returned value is not null but an actual edit class object.
         // Since the given node may be any node, we have proven that every node is classified by at least one edit class.
         if (!node.isArtifact()) {
-            throw new IllegalArgumentException("Expected an artifact node but got " + node.nodeType + "!");
+            throw new IllegalArgumentException("Expected an artifact node but got " + node.getNodeType() + "!");
         }
 
         if (node.isAdd()) {

--- a/src/main/java/org/variantsync/diffdetective/editclass/proposed/ProposedEditClasses.java
+++ b/src/main/java/org/variantsync/diffdetective/editclass/proposed/ProposedEditClasses.java
@@ -67,7 +67,7 @@ public class ProposedEditClasses implements EditClassCatalogue {
     }
 
     @Override
-    public EditClass match(DiffNode node)
+    public EditClass match(DiffNode<?> node)
     {
         // This is an inlined version of all edit classes to optimize runtime when detecting the class of a certain node.
 

--- a/src/main/java/org/variantsync/diffdetective/editclass/proposed/Reconfiguration.java
+++ b/src/main/java/org/variantsync/diffdetective/editclass/proposed/Reconfiguration.java
@@ -3,6 +3,7 @@ package org.variantsync.diffdetective.editclass.proposed;
 import org.prop4j.Node;
 import org.variantsync.diffdetective.analysis.logic.SAT;
 import org.variantsync.diffdetective.editclass.EditClass;
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.DiffType;
 
@@ -19,7 +20,7 @@ final class Reconfiguration extends EditClass {
     }
 
     @Override
-    protected boolean matchesArtifactNode(DiffNode artifactNode) {
+    protected boolean matchesArtifactNode(DiffNode<?> artifactNode) {
         final Node pcb = artifactNode.getFeatureMapping(BEFORE);
         final Node pca = artifactNode.getFeatureMapping(AFTER);
         return !SAT.implies(pcb, pca) && !SAT.implies(pca, pcb);

--- a/src/main/java/org/variantsync/diffdetective/editclass/proposed/Refactoring.java
+++ b/src/main/java/org/variantsync/diffdetective/editclass/proposed/Refactoring.java
@@ -19,7 +19,7 @@ final class Refactoring extends EditClass {
     }
 
     @Override
-    protected boolean matchesArtifactNode(DiffNode artifactNode) {
+    protected boolean matchesArtifactNode(DiffNode<?> artifactNode) {
         final Node pcb = artifactNode.getFeatureMapping(BEFORE);
         final Node pca = artifactNode.getFeatureMapping(AFTER);
         return SAT.equivalent(pcb, pca) && !artifactNode.beforePathEqualsAfterPath();

--- a/src/main/java/org/variantsync/diffdetective/editclass/proposed/RemFromPC.java
+++ b/src/main/java/org/variantsync/diffdetective/editclass/proposed/RemFromPC.java
@@ -16,7 +16,7 @@ final class RemFromPC extends EditClass {
     }
 
     @Override
-    protected boolean matchesArtifactNode(DiffNode artifactNode) {
+    protected boolean matchesArtifactNode(DiffNode<?> artifactNode) {
         return !artifactNode.getParent(BEFORE).isRem();
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/editclass/proposed/RemWithMapping.java
+++ b/src/main/java/org/variantsync/diffdetective/editclass/proposed/RemWithMapping.java
@@ -16,7 +16,7 @@ final class RemWithMapping extends EditClass {
     }
 
     @Override
-    protected boolean matchesArtifactNode(DiffNode artifactNode) {
+    protected boolean matchesArtifactNode(DiffNode<?> artifactNode) {
         return artifactNode.getParent(BEFORE).isRem();
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/editclass/proposed/Specialization.java
+++ b/src/main/java/org/variantsync/diffdetective/editclass/proposed/Specialization.java
@@ -19,7 +19,7 @@ final class Specialization extends EditClass {
     }
 
     @Override
-    protected boolean matchesArtifactNode(DiffNode artifactNode) {
+    protected boolean matchesArtifactNode(DiffNode<?> artifactNode) {
         final Node pcb = artifactNode.getFeatureMapping(BEFORE);
         final Node pca = artifactNode.getFeatureMapping(AFTER);
         return !SAT.implies(pcb, pca) && SAT.implies(pca, pcb);

--- a/src/main/java/org/variantsync/diffdetective/editclass/proposed/Untouched.java
+++ b/src/main/java/org/variantsync/diffdetective/editclass/proposed/Untouched.java
@@ -19,7 +19,7 @@ final class Untouched extends EditClass {
     }
 
     @Override
-    protected boolean matchesArtifactNode(DiffNode artifactNode) {
+    protected boolean matchesArtifactNode(DiffNode<?> artifactNode) {
         final Node pcb = artifactNode.getFeatureMapping(BEFORE);
         final Node pca = artifactNode.getFeatureMapping(AFTER);
         return SAT.equivalent(pcb, pca) && artifactNode.beforePathEqualsAfterPath();

--- a/src/main/java/org/variantsync/diffdetective/examplesearch/ExampleCriterions.java
+++ b/src/main/java/org/variantsync/diffdetective/examplesearch/ExampleCriterions.java
@@ -2,6 +2,7 @@ package org.variantsync.diffdetective.examplesearch;
 
 import org.prop4j.Literal;
 import org.prop4j.Node;
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.filter.DiffTreeFilter;
@@ -16,50 +17,64 @@ public class ExampleCriterions {
     public static final Path DefaultExamplesDirectory = Path.of("examples");
     public static final int DefaultMaxDiffLineCount = 20;
 
-    public static final TaggedPredicate<String, DiffTree> HAS_A_COMPLEX_FORMULA_BEFORE_THE_EDIT = new TaggedPredicate<>("has a complex formula before edit", ExampleCriterions::hasAtLeastOneComplexFormulaBeforeTheEdit);
-    public static final TaggedPredicate<String, DiffTree> DOES_NOT_CONTAIN_ANNOTATED_MACROS = new TaggedPredicate<>("has no annotated macros", t -> !ExampleCriterions.hasAnnotatedMacros(t));
-    public static final TaggedPredicate<String, DiffTree> HAS_EDITED_ARTIFACTS = new TaggedPredicate<>("an artifact was edited", t -> t.anyMatch(n -> n.isArtifact() && !n.isNon()));
-    public static final TaggedPredicate<String, DiffTree> HAS_ADDITIONS = new TaggedPredicate<>("has additions", t -> t.anyMatch(DiffNode::isAdd));
-    public static final TaggedPredicate<String, DiffTree> HAS_NESTING_BEFORE_EDIT = new TaggedPredicate<>("has nesting before the edit", ExampleCriterions::hasNestingBeforeEdit);
+    public static <L extends Label> TaggedPredicate<String, DiffTree<? extends L>> HAS_A_COMPLEX_FORMULA_BEFORE_THE_EDIT() {
+        return new TaggedPredicate<>("has a complex formula before edit", ExampleCriterions::hasAtLeastOneComplexFormulaBeforeTheEdit);
+    }
+    public static <L extends Label> TaggedPredicate<String, DiffTree<? extends L>> DOES_NOT_CONTAIN_ANNOTATED_MACROS() {
+        return new TaggedPredicate<>("has no annotated macros", t -> !ExampleCriterions.hasAnnotatedMacros(t));
+    }
+    public static <L extends Label> TaggedPredicate<String, DiffTree<? extends L>> HAS_EDITED_ARTIFACTS() {
+        return new TaggedPredicate<>("an artifact was edited", t -> t.anyMatch(n -> n.isArtifact() && !n.isNon()));
+    }
+    public static <L extends Label> TaggedPredicate<String, DiffTree<? extends L>> HAS_ADDITIONS() {
+        return new TaggedPredicate<>("has additions", t -> t.anyMatch(DiffNode::isAdd));
+    }
+    public static <L extends Label> TaggedPredicate<String, DiffTree<? extends L>> HAS_NESTING_BEFORE_EDIT() {
+        return new TaggedPredicate<>("has nesting before the edit", ExampleCriterions::hasNestingBeforeEdit);
+    }
 
-    public static final TaggedPredicate<String, DiffTree> HAS_ELSE = new TaggedPredicate<>(
+    public static final <L extends Label> TaggedPredicate<String, DiffTree<? extends L>> HAS_ELSE() {
+        return new TaggedPredicate<>(
             "has at least one ELSE node",
             t -> t.anyMatch(DiffNode::isElse)
-    );
-    public static TaggedPredicate<String, DiffTree> MAX_LINE_COUNT(int n) {
+        );
+    }
+    public static <L extends Label> TaggedPredicate<String, DiffTree<? extends L>> MAX_LINE_COUNT(int n) {
         return new TaggedPredicate<>(
                 "diff length <= " + n,
                 t -> diffIsNotLongerThan(t, n)
         );
     }
 
-    public static TaggedPredicate<String, DiffTree> MIN_ANNOTATIONS(int n) {
+    public static <L extends Label> TaggedPredicate<String, DiffTree<? extends L>> MIN_ANNOTATIONS(int n) {
         return new TaggedPredicate<>(
                 "has at least " + n + " annotations",
                 t -> t.computeAnnotationNodes().size() >= n
         );
     }
 
-    public static final ExplainedFilter<DiffTree> DefaultExampleConditions = new ExplainedFilter<>(
+    public static final <L extends Label> ExplainedFilter<DiffTree<L>> DefaultExampleConditions() {
+        return new ExplainedFilter<>(
             MAX_LINE_COUNT(DefaultMaxDiffLineCount),
-            HAS_NESTING_BEFORE_EDIT,
-            HAS_ADDITIONS,
-            HAS_EDITED_ARTIFACTS,
+            HAS_NESTING_BEFORE_EDIT(),
+            HAS_ADDITIONS(),
+            HAS_EDITED_ARTIFACTS(),
             DiffTreeFilter.hasAtLeastOneEditToVariability(),
             DiffTreeFilter.moreThanOneArtifactNode(),
-            DOES_NOT_CONTAIN_ANNOTATED_MACROS,
-            HAS_A_COMPLEX_FORMULA_BEFORE_THE_EDIT
-    );
+            DOES_NOT_CONTAIN_ANNOTATED_MACROS(),
+            HAS_A_COMPLEX_FORMULA_BEFORE_THE_EDIT()
+        );
+    }
 
-    private static boolean diffIsNotLongerThan(final DiffTree t, int maxLines) {
+    private static boolean diffIsNotLongerThan(final DiffTree<?> t, int maxLines) {
         return getNumberOfLinesIn(ExampleFinder.getDiff(t)) <= maxLines;
     }
 
-    private static boolean hasAnnotatedMacros(final DiffTree diffTree) {
+    private static boolean hasAnnotatedMacros(final DiffTree<?> diffTree) {
         return diffTree.anyMatch(n -> n.isArtifact() && n.getLabel().toString().trim().startsWith("#"));
     }
 
-    private static boolean hasNestingBeforeEdit(final DiffTree diffTree) {
+    private static boolean hasNestingBeforeEdit(final DiffTree<?> diffTree) {
         return diffTree.anyMatch(n ->
                            !n.isAdd()
                         && n.getDepth(BEFORE) > 2
@@ -67,7 +82,7 @@ public class ExampleCriterions {
         );
     }
 
-    private static boolean hasAtLeastOneComplexFormulaBeforeTheEdit(final DiffTree diffTree) {
+    private static boolean hasAtLeastOneComplexFormulaBeforeTheEdit(final DiffTree<?> diffTree) {
         // We would like to have a complex formula in the tree (complex := not just a positive literal).
         return diffTree.anyMatch(n -> {
             // and the formula should be visible before the edit

--- a/src/main/java/org/variantsync/diffdetective/examplesearch/Main.java
+++ b/src/main/java/org/variantsync/diffdetective/examplesearch/Main.java
@@ -4,6 +4,7 @@ import org.variantsync.diffdetective.AnalysisRunner;
 import org.variantsync.diffdetective.analysis.Analysis;
 import org.variantsync.diffdetective.datasets.PatchDiffParseOptions;
 import org.variantsync.diffdetective.datasets.Repository;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.filter.ExplainedFilter;
 import org.variantsync.diffdetective.variation.diff.render.DiffTreeRenderer;
@@ -16,19 +17,21 @@ public class Main {
     /**
      * Modify this list to your requirements on a suitable example.
      */
-    private static final ExplainedFilter<DiffTree> EXAMPLE_CRITERIONS = new ExplainedFilter<>(
+    private static final ExplainedFilter<DiffTree<? extends DiffLinesLabel>> EXAMPLE_CRITERIONS() {
+        return new ExplainedFilter<>(
             ExampleCriterions.MAX_LINE_COUNT(ExampleCriterions.DefaultMaxDiffLineCount),
-            ExampleCriterions.HAS_EDITED_ARTIFACTS,
-            ExampleCriterions.DOES_NOT_CONTAIN_ANNOTATED_MACROS,
+            ExampleCriterions.HAS_EDITED_ARTIFACTS(),
+            ExampleCriterions.DOES_NOT_CONTAIN_ANNOTATED_MACROS(),
             ExampleCriterions.MIN_ANNOTATIONS(2),
-            ExampleCriterions.HAS_ELSE
-    );
+            ExampleCriterions.HAS_ELSE()
+        );
+    }
 
     public static Analysis findExamplesIn(Repository repo, Path repoOutputDir) {
         return new Analysis(
                 "Find Running Examples in " + repo.getRepositoryName(),
                 List.of(new ExampleFinder(
-                        EXAMPLE_CRITERIONS,
+                        EXAMPLE_CRITERIONS(),
                         DiffTreeRenderer.WithinDiffDetective()
                 )),
                 repo,

--- a/src/main/java/org/variantsync/diffdetective/gumtree/DiffTreeAdapter.java
+++ b/src/main/java/org/variantsync/diffdetective/gumtree/DiffTreeAdapter.java
@@ -1,9 +1,11 @@
 package org.variantsync.diffdetective.gumtree;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.Projection;
 import org.variantsync.diffdetective.variation.diff.Time;
 import org.variantsync.diffdetective.variation.tree.VariationNode;
+import org.variantsync.functjonal.Cast;
 
 /**
  * Adapter for running Gumtree's matching algorithms on the projections of variation diffs.
@@ -11,20 +13,20 @@ import org.variantsync.diffdetective.variation.tree.VariationNode;
  * This class is almost identical to {@link VariationTreeAdapter} except that it provides type safe
  * access to the projected {@link DiffNode}.
  */
-public class DiffTreeAdapter extends VariationTreeAdapter {
-    public DiffTreeAdapter(DiffNode node, Time time) {
+public class DiffTreeAdapter<L extends Label> extends VariationTreeAdapter<L> {
+    public DiffTreeAdapter(DiffNode<L> node, Time time) {
         super(node.projection(time));
     }
 
-    public DiffTreeAdapter(Projection node) {
+    public DiffTreeAdapter(Projection<L> node) {
         super(node);
     }
 
-    protected VariationTreeAdapter newInstance(VariationNode<?> node) {
-        return new DiffTreeAdapter((Projection)node);
+    protected VariationTreeAdapter<L> newInstance(VariationNode<?, L> node) {
+        return new DiffTreeAdapter<>(Cast.unchecked(node));
     }
 
-    public DiffNode getDiffNode() {
-        return ((Projection)getVariationNode()).getBackingNode();
+    public DiffNode<L> getDiffNode() {
+        return Cast.<VariationNode<?, L>, Projection<L>>unchecked(getVariationNode()).getBackingNode();
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/gumtree/VariationTreeAdapter.java
+++ b/src/main/java/org/variantsync/diffdetective/gumtree/VariationTreeAdapter.java
@@ -5,6 +5,7 @@ import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.tree.VariationNode;
 
 import com.github.gumtreediff.tree.AbstractTree;
@@ -20,17 +21,17 @@ import com.github.gumtreediff.tree.TypeSet;
  * variation tree. Essentially it creates a copy of the tree structure and the labels of a variation
  * tree by stores a reference to the variation node which it adapts.
  */
-public class VariationTreeAdapter extends AbstractTree {
+public class VariationTreeAdapter<L extends Label> extends AbstractTree {
     private String cachedLabel;
-    private VariationNode<?> backingNode;
+    private VariationNode<?, L> backingNode;
 
-    public VariationTreeAdapter(VariationNode<?> node) {
+    public VariationTreeAdapter(VariationNode<?, L> node) {
         this.backingNode = node;
 
         if (backingNode.isConditionalAnnotation()) {
             cachedLabel = backingNode.getFormula().toString();
         } else {
-            cachedLabel = backingNode.getLabelLines().stream().collect(Collectors.joining("\n"));
+            cachedLabel = backingNode.getLabel().getLines().stream().collect(Collectors.joining("\n"));
         }
 
         var children = new ArrayList<Tree>(node.getChildren().size());
@@ -40,11 +41,11 @@ public class VariationTreeAdapter extends AbstractTree {
         setChildren(children);
     }
 
-    protected VariationTreeAdapter newInstance(VariationNode<?> node) {
-        return new VariationTreeAdapter(node);
+    protected VariationTreeAdapter newInstance(VariationNode<?, L> node) {
+        return new VariationTreeAdapter<>(node);
     }
 
-    public VariationNode<?> getVariationNode() {
+    public VariationNode<?, L> getVariationNode() {
         return backingNode;
     }
 

--- a/src/main/java/org/variantsync/diffdetective/internal/SimpleRenderer.java
+++ b/src/main/java/org/variantsync/diffdetective/internal/SimpleRenderer.java
@@ -11,6 +11,7 @@ import org.variantsync.diffdetective.mining.RWCompositePatternNodeFormat;
 import org.variantsync.diffdetective.mining.RWCompositePatternTreeFormat;
 import org.variantsync.diffdetective.util.Assert;
 import org.variantsync.diffdetective.util.FileUtils;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.parse.DiffTreeParseOptions;
 import org.variantsync.diffdetective.variation.diff.parse.DiffTreeParser;
@@ -36,20 +37,20 @@ import java.util.function.Function;
  */
 public class SimpleRenderer {
     private static final DiffTreeRenderer renderer = DiffTreeRenderer.WithinDiffDetective();
-    private static final RenderOptions renderOptions = new RenderOptions.Builder()
+    private static final RenderOptions<DiffLinesLabel> renderOptions = new RenderOptions.Builder<DiffLinesLabel>()
 //            .setNodeFormat(new ReleaseMiningDiffNodeFormat()),
-            .setNodeFormat(new MappingsDiffNodeFormat())
-            .setDpi(RenderOptions.DEFAULT.dpi() / 2)
-            .setNodesize(3*RenderOptions.DEFAULT.nodesize())
-            .setEdgesize(2*RenderOptions.DEFAULT.edgesize())
-            .setArrowsize(2*RenderOptions.DEFAULT.arrowsize())
+            .setNodeFormat(new MappingsDiffNodeFormat<>())
+            .setDpi(RenderOptions.DEFAULT().dpi() / 2)
+            .setNodesize(3*RenderOptions.DEFAULT().nodesize())
+            .setEdgesize(2*RenderOptions.DEFAULT().edgesize())
+            .setArrowsize(2*RenderOptions.DEFAULT().arrowsize())
             .setFontsize(8)
 //            .addExtraArguments("--format", "patternsrelease")
             .setCleanUpTemporaryFiles(false)
             .build();
-    private static final RenderOptions vulkanRenderOptions = new RenderOptions.Builder()
+    private static final RenderOptions<DiffLinesLabel> vulkanRenderOptions = new RenderOptions.Builder<DiffLinesLabel>()
 //            .setNodeFormat(new ReleaseMiningDiffNodeFormat()),
-            .setNodeFormat(new MappingsDiffNodeFormat())
+            .setNodeFormat(new MappingsDiffNodeFormat<>())
             .setDpi(1500)
             .setNodesize(3)
             .setEdgesize(0.1)
@@ -60,27 +61,27 @@ public class SimpleRenderer {
             .setWithlabels(false)
             .build();
 
-    private static final RenderOptions renderExampleOptions = new RenderOptions.Builder()
+    private static final RenderOptions<DiffLinesLabel> renderExampleOptions = new RenderOptions.Builder<DiffLinesLabel>()
             .setTreeFormat(new RWCompositePatternTreeFormat())
-            .setNodesize(3*RenderOptions.DEFAULT.nodesize())
-            .setEdgesize(2*RenderOptions.DEFAULT.edgesize())
-            .setArrowsize(2*RenderOptions.DEFAULT.arrowsize())
+            .setNodesize(3*RenderOptions.DEFAULT().nodesize())
+            .setEdgesize(2*RenderOptions.DEFAULT().edgesize())
+            .setArrowsize(2*RenderOptions.DEFAULT().arrowsize())
             .setFontsize(8)
             .addExtraArguments("--startlineno", "4201")
             .build();
 
-    private static final RenderOptions renderCompositePatterns = new RenderOptions.Builder()
-            .setNodesize(3*RenderOptions.DEFAULT.nodesize())
-            .setEdgesize(2*RenderOptions.DEFAULT.edgesize())
-            .setArrowsize(2*RenderOptions.DEFAULT.arrowsize())
-            .setFontsize(2*RenderOptions.DEFAULT.fontsize())
+    private static final RenderOptions<DiffLinesLabel> renderCompositePatterns = new RenderOptions.Builder<DiffLinesLabel>()
+            .setNodesize(3*RenderOptions.DEFAULT().nodesize())
+            .setEdgesize(2*RenderOptions.DEFAULT().edgesize())
+            .setArrowsize(2*RenderOptions.DEFAULT().arrowsize())
+            .setFontsize(2*RenderOptions.DEFAULT().fontsize())
             .setTreeFormat(new RWCompositePatternTreeFormat())
             .setNodeFormat(new RWCompositePatternNodeFormat())
             .setCleanUpTemporaryFiles(true)
             .addExtraArguments("--format", "patternsdebug")
             .build();
 
-    private static final RenderOptions RENDER_OPTIONS_TO_USE = renderExampleOptions;
+    private static final RenderOptions<DiffLinesLabel> RENDER_OPTIONS_TO_USE = renderExampleOptions;
 
     private final static boolean collapseMultipleCodeLines = true;
     private final static boolean ignoreEmptyLines = true;
@@ -97,7 +98,7 @@ public class SimpleRenderer {
             renderer.renderFile(fileToRender, RENDER_OPTIONS_TO_USE);
         } else if (SUPPORTED_FILE_TYPES.stream().anyMatch(extension -> FileUtils.hasExtension(fileToRender, extension))) {
             Logger.info("Rendering {}", fileToRender);
-            final DiffTree t;
+            final DiffTree<DiffLinesLabel> t;
             try {
                 t = DiffTree.fromFile(fileToRender,
                         new DiffTreeParseOptions(
@@ -160,7 +161,7 @@ public class SimpleRenderer {
             final Repository repository = Repository.fromDirectory(repoPath, repoName);
             repository.setParseOptions(repository.getParseOptions().withDiffStoragePolicy(PatchDiffParseOptions.DiffStoragePolicy.REMEMBER_STRIPPED_DIFF));
 
-            final List<DiffTreeTransformer> transform = DiffTreeMiner.Postprocessing(repository);
+            final List<DiffTreeTransformer<DiffLinesLabel>> transform = DiffTreeMiner.Postprocessing(repository);
             final PatchDiff patch = DiffTreeParser.parsePatch(repository, file, commit);
             Assert.assertNotNull(patch != null);
             DiffTreeTransformer.apply(transform, patch.getDiffTree());

--- a/src/main/java/org/variantsync/diffdetective/internal/TextDiffToTikz.java
+++ b/src/main/java/org/variantsync/diffdetective/internal/TextDiffToTikz.java
@@ -1,10 +1,10 @@
 package org.variantsync.diffdetective.internal;
 
 import org.tinylog.Logger;
-import org.variantsync.diffdetective.diff.result.DiffError;
 import org.variantsync.diffdetective.diff.result.DiffParseException;
 import org.variantsync.diffdetective.util.FileUtils;
 import org.variantsync.diffdetective.util.IO;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.parse.DiffTreeParseOptions;
@@ -13,7 +13,6 @@ import org.variantsync.diffdetective.variation.diff.serialize.GraphvizExporter;
 import org.variantsync.diffdetective.variation.diff.serialize.TikzExporter;
 import org.variantsync.diffdetective.variation.diff.serialize.edgeformat.DefaultEdgeLabelFormat;
 import org.variantsync.diffdetective.variation.diff.serialize.edgeformat.EdgeLabelFormat;
-import org.variantsync.functjonal.Result;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -28,11 +27,11 @@ public class TextDiffToTikz {
     /**
      * Format used for the test export.
      */
-    private final static Format format =
-            new Format(
+    private final static Format<DiffLinesLabel> format =
+            new Format<DiffLinesLabel>(
                     TextDiffToTikz::tikzNodeLabel,
                     // There is a bug in the exporter currently that accidentally switches direction so as a workaround we revert it here.
-                    new DefaultEdgeLabelFormat(EdgeLabelFormat.Direction.ParentToChild)
+                    new DefaultEdgeLabelFormat<>(EdgeLabelFormat.Direction.ParentToChild)
             );
 
     public static void main(String[] args) throws IOException, DiffParseException {
@@ -71,27 +70,27 @@ public class TextDiffToTikz {
         Logger.info("Using layout " + layout.getExecutableName());
         final Path targetFile = fileToConvert.resolveSibling(fileToConvert.getFileName() + ".tikz");
 
-        final DiffTree d = DiffTree.fromFile(fileToConvert, new DiffTreeParseOptions(true, true));
+        final DiffTree<DiffLinesLabel> d = DiffTree.fromFile(fileToConvert, new DiffTreeParseOptions(true, true));
         final String tikz = exportAsTikz(d, layout);
         IO.write(targetFile, tikz);
         Logger.info("Wrote file " + targetFile);
     }
 
-    public static String exportAsTikz(final DiffTree diffTree, GraphvizExporter.LayoutAlgorithm layout) throws IOException {
+    public static String exportAsTikz(final DiffTree<DiffLinesLabel> diffTree, GraphvizExporter.LayoutAlgorithm layout) throws IOException {
         // Export the test case
         var tikzOutput = new ByteArrayOutputStream();
-        new TikzExporter(format).exportDiffTree(diffTree, layout, tikzOutput);
+        new TikzExporter<DiffLinesLabel>(format).exportDiffTree(diffTree, layout, tikzOutput);
         return tikzOutput.toString();
     }
 
-    public static String tikzNodeLabel(DiffNode node) {
+    public static String tikzNodeLabel(DiffNode<? extends DiffLinesLabel> node) {
         if (node.isRoot()) {
             return "r";
         } else {
             if (node.isIf() || node.isElif()) {
                 return node.getFormula().toString(UNICODE_PROP_SYMBOLS);
             } else {
-                return node.getLabel().lines().get(0).trim();
+                return node.getLabel().getLines().get(0).trim();
             }
 //                    .map(String::trim)
 //                    .collect(Collectors.joining("<br>"));// substringBefore(node.getLabel(), StringUtils.LINEBREAK_REGEX);

--- a/src/main/java/org/variantsync/diffdetective/mining/DiffTreeMiner.java
+++ b/src/main/java/org/variantsync/diffdetective/mining/DiffTreeMiner.java
@@ -12,6 +12,7 @@ import org.variantsync.diffdetective.metadata.ExplainedFilterSummary;
 import org.variantsync.diffdetective.mining.formats.DirectedEdgeLabelFormat;
 import org.variantsync.diffdetective.mining.formats.MiningNodeFormat;
 import org.variantsync.diffdetective.mining.formats.ReleaseMiningDiffNodeFormat;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.filter.DiffTreeFilter;
 import org.variantsync.diffdetective.variation.diff.serialize.GraphFormat;
 import org.variantsync.diffdetective.variation.diff.serialize.LineGraphExportOptions;
@@ -38,9 +39,9 @@ public class DiffTreeMiner {
 //    public static final int PRINT_LARGEST_SUBJECTS = 3;
     public static final boolean DEBUG_TEST = false;
 
-    public static List<DiffTreeTransformer> Postprocessing(final Repository repository) {
-        final List<DiffTreeTransformer> processing = new ArrayList<>();
-        processing.add(new CutNonEditedSubtrees());
+    public static List<DiffTreeTransformer<DiffLinesLabel>> Postprocessing(final Repository repository) {
+        final List<DiffTreeTransformer<DiffLinesLabel>> processing = new ArrayList<>();
+        processing.add(new CutNonEditedSubtrees<>());
         processing.add(new CollapseNestedNonEditedAnnotations());
         processing.add(Starfold.IgnoreNodeOrder());
         return processing;
@@ -52,20 +53,20 @@ public class DiffTreeMiner {
                 new ReleaseMiningDiffNodeFormat();
     }
 
-    public static EdgeLabelFormat EdgeFormat() {
+    public static EdgeLabelFormat<DiffLinesLabel> EdgeFormat() {
         return EdgeFormat(NodeFormat());
     }
 
-    private static EdgeLabelFormat EdgeFormat(final MiningNodeFormat nodeFormat) {
+    private static EdgeLabelFormat<DiffLinesLabel> EdgeFormat(final MiningNodeFormat nodeFormat) {
         final EdgeLabelFormat.Direction direction = EdgeLabelFormat.Direction.ParentToChild;
         return
 //                new DefaultEdgeLabelFormat(direction);
                 new DirectedEdgeLabelFormat(nodeFormat, false, direction);
     }
 
-    public static LineGraphExportOptions MiningExportOptions(final Repository repository) {
+    public static LineGraphExportOptions<DiffLinesLabel> MiningExportOptions(final Repository repository) {
         final MiningNodeFormat nodeFormat = NodeFormat();
-        return new LineGraphExportOptions(
+        return new LineGraphExportOptions<>(
                   GraphFormat.DIFFTREE
                 // We have to ensure that all DiffTrees have unique IDs, so use name of changed file and commit hash.
                 , new CommitDiffDiffTreeLabelFormat()
@@ -152,8 +153,7 @@ public class DiffTreeMiner {
         final Consumer<Path> repoPostProcessing;
         if (SEARCH_FOR_GOOD_RUNNING_EXAMPLES) {
             repoPostProcessing = repoOutputDir -> {
-                new ExplainedFilterSummary(ExampleCriterions.DefaultExampleConditions).exportTo(repoOutputDir.resolve("runningExampleFilterReasons.txt"));
-                ExampleCriterions.DefaultExampleConditions.resetExplanations();
+                new ExplainedFilterSummary(ExampleCriterions.DefaultExampleConditions()).exportTo(repoOutputDir.resolve("runningExampleFilterReasons.txt"));
             };
         } else {
             repoPostProcessing = p -> {};

--- a/src/main/java/org/variantsync/diffdetective/mining/RWCompositePatternNodeFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/mining/RWCompositePatternNodeFormat.java
@@ -11,11 +11,11 @@ public class RWCompositePatternNodeFormat extends DebugMiningDiffNodeFormat {
         if (node.isArtifact()) {
             return ProposedEditClasses.Instance.match(node).getName() + "<br>" + node.getLabel();
         } else {
-            return node.diffType + "_" + switch (node.nodeType) {
+            return node.diffType + "_" + switch (node.getNodeType()) {
                 case IF -> "mapping<br> " + node.getLabel();
                 case ELSE -> "else";
                 case ELIF -> "elif<br>" + node.getLabel();
-                default -> node.nodeType + "<br>" + node.getLabel();
+                default -> node.getNodeType() + "<br>" + node.getLabel();
             };
         }
     }

--- a/src/main/java/org/variantsync/diffdetective/mining/RWCompositePatternNodeFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/mining/RWCompositePatternNodeFormat.java
@@ -2,11 +2,12 @@ package org.variantsync.diffdetective.mining;
 
 import org.variantsync.diffdetective.editclass.proposed.ProposedEditClasses;
 import org.variantsync.diffdetective.mining.formats.DebugMiningDiffNodeFormat;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 
 public class RWCompositePatternNodeFormat extends DebugMiningDiffNodeFormat {
     @Override
-    public String toLabel(final DiffNode node) {
+    public String toLabel(final DiffNode<? extends DiffLinesLabel> node) {
         if (node.isArtifact()) {
             return ProposedEditClasses.Instance.match(node).getName() + "<br>" + node.getLabel();
         } else {

--- a/src/main/java/org/variantsync/diffdetective/mining/formats/DebugMiningDiffNodeFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/mining/formats/DebugMiningDiffNodeFormat.java
@@ -1,9 +1,9 @@
 package org.variantsync.diffdetective.mining.formats;
 
-import org.variantsync.diffdetective.editclass.EditClass;
 import org.variantsync.diffdetective.editclass.proposed.ProposedEditClasses;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.DiffType;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.NodeType;
 import org.variantsync.functjonal.Pair;
 
@@ -16,7 +16,7 @@ import java.util.Arrays;
  */
 public class DebugMiningDiffNodeFormat implements MiningNodeFormat {
 	@Override
-	public String toLabel(final DiffNode node) {
+	public String toLabel(final DiffNode<? extends DiffLinesLabel> node) {
         if (node.isArtifact()) {
             return ProposedEditClasses.Instance.match(node).getName();
         } else {
@@ -34,7 +34,7 @@ public class DebugMiningDiffNodeFormat implements MiningNodeFormat {
             final NodeType nt = NodeType.fromName(tag.substring(nodeTypeBegin));
             return new Pair<>(dt, nt);
         } else {
-            final EditClass editClass = ProposedEditClasses.Instance.fromName(tag).orElseThrow(
+            final var editClass = ProposedEditClasses.Instance.fromName(tag).orElseThrow(
                     () -> new IllegalStateException("Label \"" + tag + "\" is neither an annotation label, nor an edit class!")
             );
 

--- a/src/main/java/org/variantsync/diffdetective/mining/formats/DebugMiningDiffNodeFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/mining/formats/DebugMiningDiffNodeFormat.java
@@ -20,7 +20,7 @@ public class DebugMiningDiffNodeFormat implements MiningNodeFormat {
         if (node.isArtifact()) {
             return ProposedEditClasses.Instance.match(node).getName();
         } else {
-            return node.diffType + "_" + node.nodeType;
+            return node.diffType + "_" + node.getNodeType();
         }
 	}
 

--- a/src/main/java/org/variantsync/diffdetective/mining/formats/DirectedEdgeLabelFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/mining/formats/DirectedEdgeLabelFormat.java
@@ -1,13 +1,14 @@
 package org.variantsync.diffdetective.mining.formats;
 
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.serialize.StyledEdge;
 import org.variantsync.diffdetective.variation.diff.serialize.edgeformat.EdgeLabelFormat;
 import org.variantsync.functjonal.Functjonal;
 
-public final class DirectedEdgeLabelFormat extends EdgeLabelFormat {
+public final class DirectedEdgeLabelFormat extends EdgeLabelFormat<DiffLinesLabel> {
     private final static String LABEL_SEPARATOR = ">";
-    private record Edge(DiffNode from, DiffNode to) {}
+    private record Edge<L extends DiffLinesLabel>(DiffNode<L> from, DiffNode<L> to) {}
 
     private final MiningNodeFormat nodeFormatter;
     private final boolean useDirectionHeuristic;
@@ -22,7 +23,7 @@ public final class DirectedEdgeLabelFormat extends EdgeLabelFormat {
         this.useDirectionHeuristic = useDirectionHeuristic;
     }
 
-    private Edge recoverEdgeDirectionFromLabelIfPossible(DiffNode hypothesizedFrom, DiffNode hypothesizedTo, String edgeLabel) {
+    private <L extends DiffLinesLabel> Edge<L> recoverEdgeDirectionFromLabelIfPossible(DiffNode<L> hypothesizedFrom, DiffNode<L> hypothesizedTo, String edgeLabel) {
         final String[] labelParts = edgeLabel.split(LABEL_SEPARATOR);
         final String fromLabel = labelParts[1];
         final String toLabel = labelParts[2];
@@ -31,19 +32,19 @@ public final class DirectedEdgeLabelFormat extends EdgeLabelFormat {
         final String hypothesizedToLabel = nodeFormatter.toLabel(hypothesizedTo);
 
         if (fromLabel.equals(hypothesizedFromLabel) || toLabel.equals(hypothesizedToLabel)) {
-            return new Edge(hypothesizedFrom, hypothesizedTo);
+            return new Edge<>(hypothesizedFrom, hypothesizedTo);
         } else if (toLabel.equals(hypothesizedFromLabel) || fromLabel.equals(hypothesizedToLabel)) {
-            return new Edge(hypothesizedTo, hypothesizedFrom);
+            return new Edge<>(hypothesizedTo, hypothesizedFrom);
         }
 
         // Can't resolve direction from labels so just assume the hypothesis was right.
-        return new Edge(hypothesizedFrom, hypothesizedTo);
+        return new Edge<>(hypothesizedFrom, hypothesizedTo);
     }
 
     @Override
-    protected void connectAccordingToLabel(DiffNode child, DiffNode parent, String edgeLabel) {
+    protected <L extends DiffLinesLabel> void connectAccordingToLabel(DiffNode<L> child, DiffNode<L> parent, String edgeLabel) {
         if (useDirectionHeuristic) {
-            final Edge e = recoverEdgeDirectionFromLabelIfPossible(child, parent, edgeLabel);
+            final Edge<L> e = recoverEdgeDirectionFromLabelIfPossible(child, parent, edgeLabel);
             child = e.from;
             parent = e.to;
         }
@@ -52,7 +53,7 @@ public final class DirectedEdgeLabelFormat extends EdgeLabelFormat {
     }
 
     @Override
-    public String labelOf(StyledEdge edge) {
+    public <L extends DiffLinesLabel> String labelOf(StyledEdge<L> edge) {
         return Functjonal.intercalate(
             LABEL_SEPARATOR,
             "",

--- a/src/main/java/org/variantsync/diffdetective/mining/formats/MiningNodeFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/mining/formats/MiningNodeFormat.java
@@ -5,18 +5,19 @@ import org.variantsync.diffdetective.util.fide.FixTrueFalse;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.DiffType;
 import org.variantsync.diffdetective.variation.diff.serialize.nodeformat.DiffNodeLabelFormat;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.NodeType;
 import org.variantsync.functjonal.Pair;
 
-public interface MiningNodeFormat extends DiffNodeLabelFormat {
+public interface MiningNodeFormat extends DiffNodeLabelFormat<DiffLinesLabel> {
     Pair<DiffType, NodeType> fromEncodedTypes(final String tag);
 
     @Override
-    default DiffNode fromLabelAndId(String lineGraphNodeLabel, int nodeId) {
+    default DiffNode<DiffLinesLabel> fromLabelAndId(String lineGraphNodeLabel, int nodeId) {
         /// We cannot reuse the id as it is just a sequential integer. It thus, does not contain any information.
         final DiffLineNumber lineFrom = new DiffLineNumber(nodeId, nodeId, nodeId);
         final DiffLineNumber lineTo = new DiffLineNumber(nodeId, nodeId, nodeId);
-        final String resultLabel = "";
+        final var resultLabel = new DiffLinesLabel();
 
         final Pair<DiffType, NodeType> types = fromEncodedTypes(lineGraphNodeLabel);
         lineFrom.as(types.first());
@@ -25,7 +26,7 @@ public interface MiningNodeFormat extends DiffNodeLabelFormat {
             return DiffNode.createArtifact(types.first(),
                     lineFrom, lineTo, resultLabel);
         } else {
-            return new DiffNode(types.first(), types.second(), lineFrom, lineTo, FixTrueFalse.True, resultLabel);
+            return new DiffNode<>(types.first(), types.second(), lineFrom, lineTo, FixTrueFalse.True, resultLabel);
         }
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/mining/formats/ReleaseMiningDiffNodeFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/mining/formats/ReleaseMiningDiffNodeFormat.java
@@ -42,7 +42,7 @@ public class ReleaseMiningDiffNodeFormat implements MiningNodeFormat {
         if (node.isArtifact()) {
             return ARTIFACT_PREFIX + toId(ProposedEditClasses.Instance.match(node));
         } else {
-            return ANNOTATION_PREFIX + node.diffType.ordinal() + node.nodeType.ordinal();
+            return ANNOTATION_PREFIX + node.diffType.ordinal() + node.getNodeType().ordinal();
         }
     }
 

--- a/src/main/java/org/variantsync/diffdetective/mining/formats/ReleaseMiningDiffNodeFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/mining/formats/ReleaseMiningDiffNodeFormat.java
@@ -5,6 +5,7 @@ import org.variantsync.diffdetective.editclass.proposed.ProposedEditClasses;
 import org.variantsync.diffdetective.util.Assert;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.DiffType;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.NodeType;
 import org.variantsync.functjonal.Pair;
 
@@ -37,7 +38,7 @@ public class ReleaseMiningDiffNodeFormat implements MiningNodeFormat {
     }
 
     @Override
-    public String toLabel(DiffNode node) {
+    public String toLabel(DiffNode<? extends DiffLinesLabel> node) {
         if (node.isArtifact()) {
             return ARTIFACT_PREFIX + toId(ProposedEditClasses.Instance.match(node));
         } else {

--- a/src/main/java/org/variantsync/diffdetective/preliminary/analysis/GDAnalysisUtils.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/analysis/GDAnalysisUtils.java
@@ -43,7 +43,7 @@ public class GDAnalysisUtils {
                 analysisResult.getCommitDiffAnalysisResults()) {
             for (PatchDiffAnalysisResult patchResult :
                     commitResult.getPatchDiffAnalysisResults()) {
-                for (PatternMatch<DiffNode> patternMatch : patchResult.getPatternMatches()) {
+                for (PatternMatch<DiffNode<?>> patternMatch : patchResult.getPatternMatches()) {
                     commits.add(commitResult.getCommitDiff().getCommitHash());
                     patches.add(patchResult.getPatchDiff().getFileName());
                     patterns.add(patternMatch.getPatternName());

--- a/src/main/java/org/variantsync/diffdetective/preliminary/analysis/GDAnalyzer.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/analysis/GDAnalyzer.java
@@ -3,6 +3,7 @@ package org.variantsync.diffdetective.preliminary.analysis;
 import org.variantsync.diffdetective.diff.git.CommitDiff;
 import org.variantsync.diffdetective.diff.git.PatchDiff;
 import org.variantsync.diffdetective.preliminary.pattern.Pattern;
+import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.preliminary.GitDiff;
 import org.variantsync.diffdetective.preliminary.analysis.data.CommitDiffAnalysisResult;
 import org.variantsync.diffdetective.preliminary.analysis.data.GDAnalysisResult;
@@ -18,23 +19,23 @@ import java.util.stream.Collectors;
  * Gets a GitDiff which is analyzed using the given edit patterns.
  */
 @Deprecated
-public abstract class GDAnalyzer<E> {
+public abstract class GDAnalyzer {
 
     final GitDiff gitDiff;
-    final List<FeatureContextReverseEngineering<E>> patterns;
+    final List<FeatureContextReverseEngineering<DiffNode<?>>> patterns;
 
-    public GDAnalyzer(GitDiff gitDiff, List<FeatureContextReverseEngineering<E>> patterns) {
+    public GDAnalyzer(GitDiff gitDiff, List<FeatureContextReverseEngineering<DiffNode<?>>> patterns) {
         this.gitDiff = gitDiff;
 //        List<Pattern<DiffNode>> patternList = new ArrayList<>(Arrays.asList(patterns));
 //        patternList.add(0, new InvalidPatchPattern<>());
         this.patterns = patterns;
     }
 
-    public List<FeatureContextReverseEngineering<E>> getReverseEngineerings() {
+    public List<FeatureContextReverseEngineering<DiffNode<?>>> getReverseEngineerings() {
         return patterns;
     }
 
-    public List<Pattern<E>> getPatterns() {
+    public List<Pattern<DiffNode<?>>> getPatterns() {
         return patterns.stream().map(FeatureContextReverseEngineering::getPattern).collect(Collectors.toList());
     }
 

--- a/src/main/java/org/variantsync/diffdetective/preliminary/analysis/TreeGDAnalyzer.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/analysis/TreeGDAnalyzer.java
@@ -8,6 +8,7 @@ import org.variantsync.diffdetective.preliminary.analysis.data.PatternMatch;
 import org.variantsync.diffdetective.preliminary.pattern.FeatureContextReverseEngineering;
 import org.variantsync.diffdetective.preliminary.pattern.elementary.*;
 import org.variantsync.diffdetective.preliminary.pattern.semantic.SemanticPattern;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 
@@ -20,9 +21,9 @@ import java.util.List;
  * Matches atomic patterns on the code nodes and semantic patterns on the annotation nodes.
  */
 @Deprecated
-public class TreeGDAnalyzer extends GDAnalyzer<DiffNode> {
-    private static List<FeatureContextReverseEngineering<DiffNode>> getPatterns(boolean atomic, boolean semantic) {
-        final List<FeatureContextReverseEngineering<DiffNode>> patterns = new ArrayList<>();
+public class TreeGDAnalyzer extends GDAnalyzer {
+    private static List<FeatureContextReverseEngineering<DiffNode<?>>> getPatterns(boolean atomic, boolean semantic) {
+        final List<FeatureContextReverseEngineering<DiffNode<?>>> patterns = new ArrayList<>();
         if (atomic) {
             patterns.addAll(List.of(
                     new FeatureContextOfAddToPC(),
@@ -37,12 +38,12 @@ public class TreeGDAnalyzer extends GDAnalyzer<DiffNode> {
             ));
         }
         if (semantic) {
-            patterns.addAll(SemanticPattern.All);
+            patterns.addAll(SemanticPattern.All());
         }
         return patterns;
     }
 
-    public TreeGDAnalyzer(GitDiff gitDiff, List<FeatureContextReverseEngineering<DiffNode>> patterns) {
+    public TreeGDAnalyzer(GitDiff gitDiff, List<FeatureContextReverseEngineering<DiffNode<?>>> patterns) {
         super(gitDiff, patterns);
     }
 
@@ -62,13 +63,13 @@ public class TreeGDAnalyzer extends GDAnalyzer<DiffNode> {
      */
     @Override
     protected PatchDiffAnalysisResult analyzePatch(PatchDiff patchDiff) {
-        List<PatternMatch<DiffNode>> results = new ArrayList<>();
+        List<PatternMatch<DiffNode<?>>> results = new ArrayList<>();
 
-        DiffTree diffTree = patchDiff.getDiffTree();
+        DiffTree<DiffLinesLabel> diffTree = patchDiff.getDiffTree();
         if(diffTree != null) {
             // match atomic patterns
-            for (DiffNode diffNode : diffTree.computeArtifactNodes()) {
-                for (FeatureContextReverseEngineering<DiffNode> pattern : patterns) {
+            for (DiffNode<DiffLinesLabel> diffNode : diffTree.computeArtifactNodes()) {
+                for (FeatureContextReverseEngineering<DiffNode<?>> pattern : patterns) {
                     if (pattern.getPattern() instanceof EditClass) {
                         results.add(pattern.createMatch(diffNode));
 //                        pattern.match(diffNode).ifPresent(results::add);
@@ -77,8 +78,8 @@ public class TreeGDAnalyzer extends GDAnalyzer<DiffNode> {
             }
 
             // match semantic patterns
-            for (DiffNode diffNode : diffTree.computeAnnotationNodes()) {
-                for (FeatureContextReverseEngineering<DiffNode> pattern : patterns) {
+            for (DiffNode<DiffLinesLabel> diffNode : diffTree.computeAnnotationNodes()) {
+                for (FeatureContextReverseEngineering<DiffNode<?>> pattern : patterns) {
                     if (pattern.getPattern() instanceof SemanticPattern s) {
                         s.match(diffNode).ifPresent(results::add);
                     }

--- a/src/main/java/org/variantsync/diffdetective/preliminary/analysis/data/PatchDiffAnalysisResult.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/analysis/data/PatchDiffAnalysisResult.java
@@ -14,18 +14,18 @@ import java.util.List;
 @Deprecated
 public class PatchDiffAnalysisResult {
     private final PatchDiff patchDiff;
-    private final List<PatternMatch<DiffNode>> patternMatches;
+    private final List<PatternMatch<DiffNode<?>>> patternMatches;
 
     public PatchDiffAnalysisResult(PatchDiff patchDiff) {
         this.patchDiff = patchDiff;
         this.patternMatches = new ArrayList<>();
     }
 
-    public void addPatternMatches(List<PatternMatch<DiffNode>> patternMatches){
+    public void addPatternMatches(List<PatternMatch<DiffNode<?>>> patternMatches){
         this.patternMatches.addAll(patternMatches);
     }
 
-    public List<PatternMatch<DiffNode>> getPatternMatches() {
+    public List<PatternMatch<DiffNode<?>>> getPatternMatches() {
         return patternMatches;
     }
 

--- a/src/main/java/org/variantsync/diffdetective/preliminary/evaluation/GDEvaluator.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/evaluation/GDEvaluator.java
@@ -32,10 +32,10 @@ public class GDEvaluator {
             "Start Line", "End Line", "Feature Context"};
 
     private final GDAnalysisResult analysisResult;
-    private final GDAnalyzer<DiffNode> analyzer;
-    private final List<PatternMatchEvaluation> pmEvaluations;
+    private final GDAnalyzer analyzer;
+    private final List<PatternMatchEvaluation<DiffNode<?>>> pmEvaluations;
 
-    public GDEvaluator(GDAnalyzer<DiffNode> analyzer, GDAnalysisResult analysisResult) {
+    public GDEvaluator(GDAnalyzer analyzer, GDAnalysisResult analysisResult) {
         this.analyzer = analyzer;
         this.analysisResult = analysisResult;
         this.pmEvaluations = getEvaluations();
@@ -47,14 +47,14 @@ public class GDEvaluator {
      *
      * @return The list of PatternMatchEvaluations
      */
-    private List<PatternMatchEvaluation> getEvaluations() {
-        List<PatternMatchEvaluation> evaluations = new ArrayList<>();
+    private List<PatternMatchEvaluation<DiffNode<?>>> getEvaluations() {
+        List<PatternMatchEvaluation<DiffNode<?>>> evaluations = new ArrayList<>();
         for (CommitDiffAnalysisResult commitResult :
                 analysisResult.getCommitDiffAnalysisResults()) {
             for (PatchDiffAnalysisResult patchResult :
                     commitResult.getPatchDiffAnalysisResults()) {
-                for (PatternMatch<DiffNode> patternMatch : patchResult.getPatternMatches()) {
-                    PatternMatchEvaluation pme = new PatternMatchEvaluation(commitResult,
+                for (PatternMatch<DiffNode<?>> patternMatch : patchResult.getPatternMatches()) {
+                    PatternMatchEvaluation<DiffNode<?>> pme = new PatternMatchEvaluation<DiffNode<?>>(commitResult,
                             patchResult, patternMatch, patternMatch.getFeatureContexts());
                     evaluations.add(pme);
                 }
@@ -71,7 +71,7 @@ public class GDEvaluator {
     public <E> int[] getPatternCounts(List<Pattern<E>> patterns) {
         int[] patternCounts = new int[patterns.size()];
 
-        for (PatternMatchEvaluation pme : pmEvaluations) {
+        for (PatternMatchEvaluation<DiffNode<?>> pme : pmEvaluations) {
             for (int i = 0; i < patterns.size(); i++) {
                 if (pme.getPatternMatch().getPattern().getClass() == patterns.get(i).getClass()) {
                     patternCounts[i]++;
@@ -93,7 +93,7 @@ public class GDEvaluator {
         for (CommitDiffAnalysisResult cdar : analysisResult.getCommitDiffAnalysisResults()) {
             for (PatchDiffAnalysisResult pdar : cdar.getPatchDiffAnalysisResults()) {
                 for (int i = 0; i < patterns.size(); i++) {
-                    for (PatternMatch<DiffNode> pm : pdar.getPatternMatches()) {
+                    for (PatternMatch<DiffNode<?>> pm : pdar.getPatternMatches()) {
                         if (pm.getPattern().getClass() == patterns.get(i).getClass()) {
                             patternCounts[i]++;
                             break;
@@ -108,7 +108,7 @@ public class GDEvaluator {
     private <E> int[] getLineCounts(List<Pattern<E>> patterns) {
         int[] lineCounts = new int[patterns.size()];
 
-        for (PatternMatchEvaluation pme : pmEvaluations) {
+        for (PatternMatchEvaluation<DiffNode<?>> pme : pmEvaluations) {
             for (int i = 0; i < patterns.size(); i++) {
                 if (pme.getPatternMatch().getPattern().getClass() == patterns.get(i).getClass()) {
                     lineCounts[i] += pme.getPatternMatch().getEndLineDiff() - pme.getPatternMatch().getStartLineDiff();
@@ -120,7 +120,7 @@ public class GDEvaluator {
 
     public int getUnknownFeatureContextAmount() {
         int amount = 0;
-        for (PatternMatchEvaluation pme : pmEvaluations) {
+        for (PatternMatchEvaluation<DiffNode<?>> pme : pmEvaluations) {
             if (pme.isFeatureContextUnknown()) {
                 amount++;
             }
@@ -130,7 +130,7 @@ public class GDEvaluator {
 
     public int getFeatureContextNullAmount() {
         int amount = 0;
-        for (PatternMatchEvaluation pme : pmEvaluations) {
+        for (PatternMatchEvaluation<DiffNode<?>> pme : pmEvaluations) {
             if (!pme.isFeatureContextUnknown() && pme.canFeatureContextBeNull()) {
                 amount++;
             }
@@ -146,7 +146,7 @@ public class GDEvaluator {
                 analysisResult.getCommitDiffAnalysisResults()) {
             for (PatchDiffAnalysisResult patchResult :
                     commitResult.getPatchDiffAnalysisResults()) {
-                for (PatternMatch<DiffNode> patternMatch : patchResult.getPatternMatches()) {
+                for (PatternMatch<DiffNode<?>> patternMatch : patchResult.getPatternMatches()) {
                     if (patternName.equals(patternMatch.getPatternName())) {
                         patches.add(patchResult.getPatchDiff());
                     }
@@ -198,7 +198,7 @@ public class GDEvaluator {
     public int[] getFeatureContextComplexityAmounts() {
         int[] amounts =
                 new int[getMaxFeatureContextComplexityPme().getFeatureContextComplexity() + 1];
-        for (PatternMatchEvaluation pme : pmEvaluations) {
+        for (PatternMatchEvaluation<DiffNode<?>> pme : pmEvaluations) {
             if (!pme.isFeatureContextUnknown()) {
                 amounts[pme.getFeatureContextComplexity()]++;
             }
@@ -209,7 +209,7 @@ public class GDEvaluator {
     public double getAvgFeatureContextComplexity() {
         int sum = 0;
         int amount = 0;
-        for (PatternMatchEvaluation pme : pmEvaluations) {
+        for (PatternMatchEvaluation<DiffNode<?>> pme : pmEvaluations) {
             if (!pme.isFeatureContextUnknown()) {
                 sum += pme.getFeatureContextComplexity();
                 amount++;
@@ -218,10 +218,10 @@ public class GDEvaluator {
         return (double) sum / amount;
     }
 
-    public PatternMatchEvaluation getMinFeatureContextComplexityPme() {
+    public PatternMatchEvaluation<DiffNode<?>> getMinFeatureContextComplexityPme() {
         int min = Integer.MAX_VALUE;
-        PatternMatchEvaluation minPme = null;
-        for (PatternMatchEvaluation pme : pmEvaluations) {
+        PatternMatchEvaluation<DiffNode<?>> minPme = null;
+        for (PatternMatchEvaluation<DiffNode<?>> pme : pmEvaluations) {
             if (!pme.isFeatureContextUnknown() && pme.getFeatureContextComplexity() < min) {
                 min = pme.getFeatureContextComplexity();
                 minPme = pme;
@@ -230,10 +230,10 @@ public class GDEvaluator {
         return minPme;
     }
 
-    public PatternMatchEvaluation getMaxFeatureContextComplexityPme() {
+    public PatternMatchEvaluation<DiffNode<?>> getMaxFeatureContextComplexityPme() {
         int max = Integer.MIN_VALUE;
-        PatternMatchEvaluation maxPme = null;
-        for (PatternMatchEvaluation pme : pmEvaluations) {
+        PatternMatchEvaluation<DiffNode<?>> maxPme = null;
+        for (PatternMatchEvaluation<DiffNode<?>> pme : pmEvaluations) {
             if (!pme.isFeatureContextUnknown() && pme.getFeatureContextComplexity() > max) {
                 max = pme.getFeatureContextComplexity();
                 maxPme = pme;
@@ -309,7 +309,7 @@ public class GDEvaluator {
      */
     public List<FeatureContext> getDifferentFeatureContextsFromCommit(CommitDiffAnalysisResult commitResult) {
         List<FeatureContext[]> allFeatureContexts = new ArrayList<>();
-        for (PatternMatchEvaluation pme : pmEvaluations) {
+        for (PatternMatchEvaluation<DiffNode<?>> pme : pmEvaluations) {
             if (!pme.isFeatureContextUnknown() && pme.getCommit().equals(commitResult)) {
                 allFeatureContexts.add(pme.getFeatureContexts());
             }
@@ -415,7 +415,7 @@ public class GDEvaluator {
         List<Integer> endLines = new ArrayList<>();
         List<String> featureContexts = new ArrayList<>();
 
-        for (PatternMatchEvaluation pme : pmEvaluations) {
+        for (PatternMatchEvaluation<DiffNode<?>> pme : pmEvaluations) {
             commits.add(pme.getCommit().getCommitDiff().getCommitHash());
             patches.add(pme.getPatch().getPatchDiff().getFileName());
             patterns.add(pme.getPatternMatch().getPatternName());
@@ -571,13 +571,13 @@ public class GDEvaluator {
 
         System.out.printf("Average feature context complexity: %f%n",
                 getAvgFeatureContextComplexity());
-        PatternMatchEvaluation maxPme = getMaxFeatureContextComplexityPme();
+        PatternMatchEvaluation<DiffNode<?>> maxPme = getMaxFeatureContextComplexityPme();
         if (maxPme != null) {
             System.out.printf("Max feature context complexity: %d (%s)%n",
                     maxPme.getFeatureContextComplexity(),
                     Arrays.toString(maxPme.getFeatureContexts()));
         }
-        PatternMatchEvaluation minPme = getMinFeatureContextComplexityPme();
+        PatternMatchEvaluation<DiffNode<?>> minPme = getMinFeatureContextComplexityPme();
         if (minPme != null) {
             System.out.printf("Min feature context complexity: %d (%s)%n",
                     minPme.getFeatureContextComplexity(),

--- a/src/main/java/org/variantsync/diffdetective/preliminary/evaluation/PatternMatchEvaluation.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/evaluation/PatternMatchEvaluation.java
@@ -9,15 +9,15 @@ import org.variantsync.diffdetective.preliminary.analysis.data.PatternMatch;
  * Data class containing a PatternMatch, the possible reverse-engineered FeatureContexts and the complexity of the feature context.
  */
 @Deprecated
-public class PatternMatchEvaluation {
+public class PatternMatchEvaluation<L> {
     private final CommitDiffAnalysisResult commit;
     private final PatchDiffAnalysisResult patch;
-    private final PatternMatch patternMatch;
+    private final PatternMatch<L> patternMatch;
     private final FeatureContext[] featureContexts;
     private final int featureContextComplexity;
 
     public PatternMatchEvaluation(CommitDiffAnalysisResult commit, PatchDiffAnalysisResult patch,
-                                  PatternMatch patternMatch, FeatureContext[] featureContexts) {
+                                  PatternMatch<L> patternMatch, FeatureContext[] featureContexts) {
         this.commit = commit;
         this.patch = patch;
         this.patternMatch = patternMatch;
@@ -75,7 +75,7 @@ public class PatternMatchEvaluation {
         return patch;
     }
 
-    public PatternMatch getPatternMatch() {
+    public PatternMatch<L> getPatternMatch() {
         return patternMatch;
     }
 

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/FeatureContextReverseEngineering.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/FeatureContextReverseEngineering.java
@@ -1,6 +1,5 @@
 package org.variantsync.diffdetective.preliminary.pattern;
 
-import org.variantsync.diffdetective.preliminary.pattern.Pattern;
 import org.variantsync.diffdetective.preliminary.analysis.data.PatternMatch;
 import org.variantsync.diffdetective.preliminary.evaluation.FeatureContext;
 

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfAddToPC.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfAddToPC.java
@@ -12,14 +12,14 @@ import org.variantsync.diffdetective.variation.diff.DiffNode;
 import static org.variantsync.diffdetective.variation.diff.Time.AFTER;
 
 @Deprecated
-public final class FeatureContextOfAddToPC implements FeatureContextReverseEngineering<DiffNode> {
+public final class FeatureContextOfAddToPC implements FeatureContextReverseEngineering<DiffNode<?>> {
     @Override
-    public Pattern<DiffNode> getPattern() {
+    public Pattern<DiffNode<?>> getPattern() {
         return ProposedEditClasses.AddToPC;
     }
 
     @Override
-    public PatternMatch<DiffNode> createMatch(DiffNode codeNode) {
+    public PatternMatch<DiffNode<?>> createMatch(DiffNode<?> codeNode) {
         final Node fm = codeNode.getParent(AFTER).getFeatureMapping(AFTER);
         final LineRange diffLines = codeNode.getLinesInDiff();
 
@@ -29,7 +29,7 @@ public final class FeatureContextOfAddToPC implements FeatureContextReverseEngin
     }
 
     @Override
-    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode> patternMatch) {
+    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode<?>> patternMatch) {
         return new FeatureContext[]{
                 new FeatureContext(patternMatch.getFeatureMappings()[0])
         };

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfAddWithMapping.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfAddWithMapping.java
@@ -12,14 +12,14 @@ import org.variantsync.diffdetective.variation.diff.DiffNode;
 import static org.variantsync.diffdetective.variation.diff.Time.AFTER;
 
 @Deprecated
-public final class FeatureContextOfAddWithMapping implements FeatureContextReverseEngineering<DiffNode> {
+public final class FeatureContextOfAddWithMapping implements FeatureContextReverseEngineering<DiffNode<?>> {
     @Override
-    public Pattern<DiffNode> getPattern() {
+    public Pattern<DiffNode<?>> getPattern() {
         return ProposedEditClasses.AddWithMapping;
     }
 
     @Override
-    public PatternMatch<DiffNode> createMatch(DiffNode codeNode) {
+    public PatternMatch<DiffNode<?>> createMatch(DiffNode<?> codeNode) {
         final Node fm = codeNode.getParent(AFTER).getFeatureMapping(AFTER);
         final LineRange diffLines = codeNode.getLinesInDiff();
 
@@ -30,7 +30,7 @@ public final class FeatureContextOfAddWithMapping implements FeatureContextRever
     }
 
     @Override
-    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode> patternMatch) {
+    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode<?>> patternMatch) {
         return new FeatureContext[]{
                 new FeatureContext(patternMatch.getFeatureMappings()[0])
         };

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfGeneralization.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfGeneralization.java
@@ -9,14 +9,14 @@ import org.variantsync.diffdetective.preliminary.pattern.Pattern;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 
 @Deprecated
-public final class FeatureContextOfGeneralization implements FeatureContextReverseEngineering<DiffNode> {
+public final class FeatureContextOfGeneralization implements FeatureContextReverseEngineering<DiffNode<?>> {
     @Override
-    public Pattern<DiffNode> getPattern() {
+    public Pattern<DiffNode<?>> getPattern() {
         return ProposedEditClasses.Generalization;
     }
 
     @Override
-    public PatternMatch<DiffNode> createMatch(DiffNode codeNode) {
+    public PatternMatch<DiffNode<?>> createMatch(DiffNode<?> codeNode) {
         final LineRange diffLines = codeNode.getLinesInDiff();
         return new PatternMatch<>(this,
                 diffLines.fromInclusive(), diffLines.toExclusive()
@@ -24,7 +24,7 @@ public final class FeatureContextOfGeneralization implements FeatureContextRever
     }
 
     @Override
-    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode> patternMatch) {
+    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode<?>> patternMatch) {
         return new FeatureContext[0];
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfReconfiguration.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfReconfiguration.java
@@ -9,14 +9,14 @@ import org.variantsync.diffdetective.preliminary.pattern.Pattern;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 
 @Deprecated
-public final class FeatureContextOfReconfiguration implements FeatureContextReverseEngineering<DiffNode> {
+public final class FeatureContextOfReconfiguration implements FeatureContextReverseEngineering<DiffNode<?>> {
     @Override
-    public Pattern<DiffNode> getPattern() {
+    public Pattern<DiffNode<?>> getPattern() {
         return ProposedEditClasses.Reconfiguration;
     }
 
     @Override
-    public PatternMatch<DiffNode> createMatch(DiffNode codeNode) {
+    public PatternMatch<DiffNode<?>> createMatch(DiffNode<?> codeNode) {
         final LineRange diffLines = codeNode.getLinesInDiff();
         return new PatternMatch<>(this,
                 diffLines.fromInclusive(), diffLines.toExclusive()
@@ -24,7 +24,7 @@ public final class FeatureContextOfReconfiguration implements FeatureContextReve
     }
 
     @Override
-    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode> patternMatch) {
+    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode<?>> patternMatch) {
         return new FeatureContext[0];
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfRefactoring.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfRefactoring.java
@@ -9,14 +9,14 @@ import org.variantsync.diffdetective.preliminary.pattern.Pattern;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 
 @Deprecated
-public final class FeatureContextOfRefactoring implements FeatureContextReverseEngineering<DiffNode> {
+public final class FeatureContextOfRefactoring implements FeatureContextReverseEngineering<DiffNode<?>> {
     @Override
-    public Pattern<DiffNode> getPattern() {
+    public Pattern<DiffNode<?>> getPattern() {
         return ProposedEditClasses.Refactoring;
     }
 
     @Override
-    public PatternMatch<DiffNode> createMatch(DiffNode codeNode) {
+    public PatternMatch<DiffNode<?>> createMatch(DiffNode<?> codeNode) {
         final LineRange diffLines = codeNode.getLinesInDiff();
         return new PatternMatch<>(this,
                 diffLines.fromInclusive(), diffLines.toExclusive()
@@ -24,7 +24,7 @@ public final class FeatureContextOfRefactoring implements FeatureContextReverseE
     }
 
     @Override
-    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode> patternMatch) {
+    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode<?>> patternMatch) {
         return new FeatureContext[0];
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfRemFromPC.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfRemFromPC.java
@@ -12,14 +12,14 @@ import org.variantsync.diffdetective.variation.diff.DiffNode;
 import static org.variantsync.diffdetective.variation.diff.Time.BEFORE;
 
 @Deprecated
-public final class FeatureContextOfRemFromPC implements FeatureContextReverseEngineering<DiffNode> {
+public final class FeatureContextOfRemFromPC implements FeatureContextReverseEngineering<DiffNode<?>> {
     @Override
-    public Pattern<DiffNode> getPattern() {
+    public Pattern<DiffNode<?>> getPattern() {
         return ProposedEditClasses.RemFromPC;
     }
 
     @Override
-    public PatternMatch<DiffNode> createMatch(DiffNode codeNode) {
+    public PatternMatch<DiffNode<?>> createMatch(DiffNode<?> codeNode) {
         final Node fm = codeNode.getParent(BEFORE).getFeatureMapping(BEFORE);
         final LineRange diffLines = codeNode.getLinesInDiff();
 
@@ -29,7 +29,7 @@ public final class FeatureContextOfRemFromPC implements FeatureContextReverseEng
     }
 
     @Override
-    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode> patternMatch) {
+    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode<?>> patternMatch) {
         return new FeatureContext[]{
                 new FeatureContext(patternMatch.getFeatureMappings()[0], true)
         };

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfRemWithMapping.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfRemWithMapping.java
@@ -12,14 +12,14 @@ import org.variantsync.diffdetective.variation.diff.DiffNode;
 import static org.variantsync.diffdetective.variation.diff.Time.BEFORE;
 
 @Deprecated
-public final class FeatureContextOfRemWithMapping implements FeatureContextReverseEngineering<DiffNode> {
+public final class FeatureContextOfRemWithMapping implements FeatureContextReverseEngineering<DiffNode<?>> {
     @Override
-    public Pattern<DiffNode> getPattern() {
+    public Pattern<DiffNode<?>> getPattern() {
         return ProposedEditClasses.RemWithMapping;
     }
 
     @Override
-    public PatternMatch<DiffNode> createMatch(DiffNode codeNode) {
+    public PatternMatch<DiffNode<?>> createMatch(DiffNode<?> codeNode) {
         final Node fm = codeNode.getParent(BEFORE).getFeatureMapping(BEFORE);
         final LineRange diffLines = codeNode.getLinesInDiff();
 
@@ -29,7 +29,7 @@ public final class FeatureContextOfRemWithMapping implements FeatureContextRever
     }
 
     @Override
-    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode> patternMatch) {
+    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode<?>> patternMatch) {
         return new FeatureContext[]{
                 new FeatureContext(null),
                 new FeatureContext(patternMatch.getFeatureMappings()[0], true)

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfSpecialization.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfSpecialization.java
@@ -9,14 +9,14 @@ import org.variantsync.diffdetective.preliminary.pattern.Pattern;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 
 @Deprecated
-public final class FeatureContextOfSpecialization implements FeatureContextReverseEngineering<DiffNode> {
+public final class FeatureContextOfSpecialization implements FeatureContextReverseEngineering<DiffNode<?>> {
     @Override
-    public Pattern<DiffNode> getPattern() {
+    public Pattern<DiffNode<?>> getPattern() {
         return ProposedEditClasses.Specialization;
     }
 
     @Override
-    public PatternMatch<DiffNode> createMatch(DiffNode codeNode) {
+    public PatternMatch<DiffNode<?>> createMatch(DiffNode<?> codeNode) {
         final LineRange diffLines = codeNode.getLinesInDiff();
         return new PatternMatch<>(this,
                 diffLines.fromInclusive(), diffLines.toExclusive()
@@ -24,7 +24,7 @@ public final class FeatureContextOfSpecialization implements FeatureContextRever
     }
 
     @Override
-    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode> patternMatch) {
+    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode<?>> patternMatch) {
         return new FeatureContext[0];
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfUntouched.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/elementary/FeatureContextOfUntouched.java
@@ -9,14 +9,14 @@ import org.variantsync.diffdetective.preliminary.pattern.Pattern;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 
 @Deprecated
-public class FeatureContextOfUntouched implements FeatureContextReverseEngineering<DiffNode> {
+public class FeatureContextOfUntouched implements FeatureContextReverseEngineering<DiffNode<?>> {
     @Override
-    public Pattern<DiffNode> getPattern() {
+    public Pattern<DiffNode<?>> getPattern() {
         return ProposedEditClasses.Untouched;
     }
 
     @Override
-    public PatternMatch<DiffNode> createMatch(DiffNode codeNode) {
+    public PatternMatch<DiffNode<?>> createMatch(DiffNode<?> codeNode) {
         final LineRange diffLines = codeNode.getLinesInDiff();
         return new PatternMatch<>(this,
                 diffLines.fromInclusive(), diffLines.toExclusive()
@@ -24,7 +24,7 @@ public class FeatureContextOfUntouched implements FeatureContextReverseEngineeri
     }
 
     @Override
-    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode> patternMatch) {
+    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode<?>> patternMatch) {
         return new FeatureContext[0];
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/semantic/AddIfdefElif.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/semantic/AddIfdefElif.java
@@ -28,11 +28,11 @@ class AddIfdefElif extends SemanticPattern {
                 they also need to have an added code child
      */
     @Override
-    public Optional<PatternMatch<DiffNode>> match(DiffNode annotationNode) {
+    public Optional<PatternMatch<DiffNode<?>>> match(DiffNode<?> annotationNode) {
         if(annotationNode.isAdd() && annotationNode.isIf()){
             boolean addedCodeInIf = false;
-            DiffNode elifNode = null;
-            for(DiffNode child : annotationNode.getAllChildren()){
+            DiffNode<?> elifNode = null;
+            for(DiffNode<?> child : annotationNode.getAllChildren()){
                 if(child.isArtifact() && child.isAdd()){
                     addedCodeInIf = true;
                 }
@@ -57,11 +57,11 @@ class AddIfdefElif extends SemanticPattern {
         return Optional.empty();
     }
 
-    private boolean isValidElif(DiffNode elifNode, List<Node> mappings) {
+    private boolean isValidElif(DiffNode<?> elifNode, List<Node> mappings) {
         boolean addedCode = false;
-        DiffNode nextNode = null;
+        DiffNode<?> nextNode = null;
 
-        for(DiffNode child : elifNode.getAllChildren()){
+        for(DiffNode<?> child : elifNode.getAllChildren()){
             if(child.isArtifact() && child.isAdd()){
                 addedCode = true;
             }
@@ -78,7 +78,7 @@ class AddIfdefElif extends SemanticPattern {
     }
 
     @Override
-    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode> patternMatch) {
+    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode<?>> patternMatch) {
         FeatureContext[] featureContexts = new FeatureContext[patternMatch.getFeatureMappings().length];
         for (int i = 0; i < featureContexts.length; i++) {
             featureContexts[i] = new FeatureContext(patternMatch.getFeatureMappings()[i]);

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/semantic/AddIfdefElse.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/semantic/AddIfdefElse.java
@@ -24,11 +24,11 @@ class AddIfdefElse extends SemanticPattern {
           which has an added code child
      */
     @Override
-    public Optional<PatternMatch<DiffNode>> match(DiffNode annotationNode) {
+    public Optional<PatternMatch<DiffNode<?>>> match(DiffNode<?> annotationNode) {
         if(annotationNode.isAdd() && annotationNode.isIf()){
             boolean addedCodeInIf = false;
-            DiffNode elseNode = null;
-            for(DiffNode child : annotationNode.getAllChildren()){
+            DiffNode<?> elseNode = null;
+            for(DiffNode<?> child : annotationNode.getAllChildren()){
                 if(child.isElif()){
                     return Optional.empty();
                 }
@@ -45,7 +45,7 @@ class AddIfdefElse extends SemanticPattern {
             }
 
             boolean addedCodeInElse = false;
-            for(DiffNode child : elseNode.getAllChildren()) {
+            for(DiffNode<?> child : elseNode.getAllChildren()) {
                 if(child.isArtifact() && child.isAdd()){
                     addedCodeInElse = true;
                 }
@@ -65,7 +65,7 @@ class AddIfdefElse extends SemanticPattern {
     }
 
     @Override
-    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode> patternMatch) {
+    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode<?>> patternMatch) {
         return new FeatureContext[]{
                 new FeatureContext(patternMatch.getFeatureMappings()[0]),
                 new FeatureContext(new Not(patternMatch.getFeatureMappings()[0]))

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/semantic/AddIfdefWrapElse.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/semantic/AddIfdefWrapElse.java
@@ -23,11 +23,11 @@ class AddIfdefWrapElse extends SemanticPattern {
             which has an unchanged code child
      */
     @Override
-    public Optional<PatternMatch<DiffNode>> match(DiffNode annotationNode) {
+    public Optional<PatternMatch<DiffNode<?>>> match(DiffNode<?> annotationNode) {
         if(annotationNode.isAdd() && annotationNode.isIf()){
             boolean addedCodeInIf = false;
-            DiffNode elseNode = null;
-            for(DiffNode child : annotationNode.getAllChildren()){
+            DiffNode<?> elseNode = null;
+            for(DiffNode<?> child : annotationNode.getAllChildren()){
                 if(child.isElif()){
                     return Optional.empty();
                 }
@@ -44,7 +44,7 @@ class AddIfdefWrapElse extends SemanticPattern {
             }
 
             boolean noneCodeInElse = false;
-            for(DiffNode child : elseNode.getAllChildren()){
+            for(DiffNode<?> child : elseNode.getAllChildren()){
                 if(child.isArtifact() && child.isNon()){
                     noneCodeInElse = true;
                 }
@@ -64,7 +64,7 @@ class AddIfdefWrapElse extends SemanticPattern {
     }
 
     @Override
-    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode> patternMatch) {
+    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode<?>> patternMatch) {
         return new FeatureContext[]{
                 new FeatureContext(patternMatch.getFeatureMappings()[0])
         };

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/semantic/AddIfdefWrapThen.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/semantic/AddIfdefWrapThen.java
@@ -24,11 +24,11 @@ class AddIfdefWrapThen extends SemanticPattern {
             which has an added code child
      */
     @Override
-    public Optional<PatternMatch<DiffNode>> match(DiffNode annotationNode) {
+    public Optional<PatternMatch<DiffNode<?>>> match(DiffNode<?> annotationNode) {
         if(annotationNode.isAdd() && annotationNode.isIf()){
             boolean nonCodeInIf = false;
-            DiffNode elseNode = null;
-            for(DiffNode child : annotationNode.getAllChildren()){
+            DiffNode<?> elseNode = null;
+            for(DiffNode<?> child : annotationNode.getAllChildren()){
                 if(child.isElif()){
                     return Optional.empty();
                 }
@@ -45,7 +45,7 @@ class AddIfdefWrapThen extends SemanticPattern {
             }
 
             boolean addedCodeInElse = false;
-            for(DiffNode child : elseNode.getAllChildren()){
+            for(DiffNode<?> child : elseNode.getAllChildren()){
                 if(child.isArtifact() && child.isAdd()){
                     addedCodeInElse = true;
                 }
@@ -65,7 +65,7 @@ class AddIfdefWrapThen extends SemanticPattern {
     }
 
     @Override
-    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode> patternMatch) {
+    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode<?>> patternMatch) {
         return new FeatureContext[]{
                 new FeatureContext(new Not(patternMatch.getFeatureMappings()[0]))
         };

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/semantic/MoveElse.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/semantic/MoveElse.java
@@ -4,9 +4,7 @@ import org.variantsync.diffdetective.preliminary.analysis.data.PatternMatch;
 import org.variantsync.diffdetective.preliminary.evaluation.FeatureContext;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 
-import java.util.Collection;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import static org.variantsync.diffdetective.variation.diff.Time.AFTER;
 
@@ -23,11 +21,11 @@ class MoveElse extends SemanticPattern {
         the parent has a child that is either also a child of the added or the removed else node
      */
     @Override
-    public Optional<PatternMatch<DiffNode>> match(DiffNode annotationNode) {
+    public Optional<PatternMatch<DiffNode<?>>> match(DiffNode<?> annotationNode) {
         if(annotationNode.isAdd() && annotationNode.isElse()){
 
-            DiffNode removedElse = null;
-            for(DiffNode parentsChild : annotationNode.getParent(AFTER).getAllChildren()){
+            DiffNode<?> removedElse = null;
+            for(DiffNode<?> parentsChild : annotationNode.getParent(AFTER).getAllChildren()){
                 if(parentsChild.isElse() && parentsChild.isRem()){
                     removedElse = parentsChild;
                     break;
@@ -38,9 +36,9 @@ class MoveElse extends SemanticPattern {
                 return Optional.empty();
             }
 
-            Collection<DiffNode> annotationChildren = annotationNode.getParent(AFTER).getAllChildrenSet();
-            Stream<DiffNode> commonAddElse = annotationNode.getAllChildrenStream().filter(annotationChildren::contains);
-            Stream<DiffNode> commonRemElse = removedElse.getAllChildrenStream().filter(annotationChildren::contains);
+            var annotationChildren = annotationNode.getParent(AFTER).getAllChildrenSet();
+            var commonAddElse = annotationNode.getAllChildrenStream().filter(annotationChildren::contains);
+            var commonRemElse = removedElse.getAllChildrenStream().filter(annotationChildren::contains);
 
             if(commonAddElse.limit(1).count() == 0 && commonRemElse.limit(1).count() == 0){
                 return Optional.empty();
@@ -55,7 +53,7 @@ class MoveElse extends SemanticPattern {
     }
 
     @Override
-    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode> patternMatch) {
+    public FeatureContext[] getFeatureContexts(PatternMatch<DiffNode<?>> patternMatch) {
         return new FeatureContext[0];
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/preliminary/pattern/semantic/SemanticPattern.java
+++ b/src/main/java/org/variantsync/diffdetective/preliminary/pattern/semantic/SemanticPattern.java
@@ -9,35 +9,37 @@ import java.util.List;
 import java.util.Optional;
 
 @Deprecated
-public abstract class SemanticPattern extends Pattern<DiffNode> implements FeatureContextReverseEngineering<DiffNode> {
+public abstract class SemanticPattern extends Pattern<DiffNode<?>> implements FeatureContextReverseEngineering<DiffNode<?>> {
     public static final SemanticPattern AddIfdefElif = new AddIfdefElif();
     public static final SemanticPattern AddIfdefElse = new AddIfdefElse();
     public static final SemanticPattern AddIfdefWrapElse = new AddIfdefWrapElse();
     public static final SemanticPattern AddIfdefWrapThen = new AddIfdefWrapThen();
     public static final SemanticPattern MoveElse = new MoveElse();
 
-    public static final List<SemanticPattern> All = List.of(
+    public static final List<SemanticPattern> All() {
+        return  List.of(
             AddIfdefElif, AddIfdefElse, AddIfdefWrapElse, AddIfdefWrapThen, MoveElse
-    );
+        );
+    }
 
     public SemanticPattern(String name) {
         super(name);
     }
 
     @Override
-    public boolean matches(DiffNode diffNode) {
+    public boolean matches(DiffNode<?> diffNode) {
         return match(diffNode).isPresent();
     }
 
-    public abstract Optional<PatternMatch<DiffNode>> match(DiffNode annotationNode);
+    public abstract Optional<PatternMatch<DiffNode<?>>> match(DiffNode<?> annotationNode);
 
     @Override
-    public PatternMatch<DiffNode> createMatch(DiffNode diffNode) {
+    public PatternMatch<DiffNode<?>> createMatch(DiffNode<?> diffNode) {
         return match(diffNode).orElseThrow();
     }
 
     @Override
-    public Pattern<DiffNode> getPattern() {
+    public Pattern<DiffNode<?>> getPattern() {
         return this;
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/show/Show.java
+++ b/src/main/java/org/variantsync/diffdetective/show/Show.java
@@ -1,66 +1,85 @@
 package org.variantsync.diffdetective.show;
 
+import java.util.List;
+
 import org.variantsync.diffdetective.diff.text.DiffLineNumber;
 import org.variantsync.diffdetective.show.engine.GameEngine;
 import org.variantsync.diffdetective.show.engine.geom.Vec2;
 import org.variantsync.diffdetective.show.variation.DiffTreeApp;
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.bad.BadVDiff;
+import org.variantsync.diffdetective.variation.diff.serialize.nodeformat.DiffNodeLabelFormat;
 import org.variantsync.diffdetective.variation.tree.VariationTree;
 
 public class Show {
     public static Vec2 DEFAULT_RESOLUTION = new Vec2(800, 600);
-    
-    public static GameEngine diff(final DiffTree d, final String title) {
-        return new GameEngine(new DiffTreeApp(
+
+    public static <L extends Label> GameEngine diff(final DiffTree<L> d, final String title, List<DiffNodeLabelFormat<L>> availableFormats) {
+        return new GameEngine(new DiffTreeApp<>(
                 title,
                 d,
-                DEFAULT_RESOLUTION
+                DEFAULT_RESOLUTION,
+                availableFormats
         ));
     }
 
-    public static GameEngine diff(final DiffTree d) {
+    public static GameEngine diff(final DiffTree<?> d, final String title) {
+        return diff(d, title, DiffTreeApp.DEFAULT_FORMATS());
+    }
+
+    public static GameEngine diff(final DiffTree<?> d) {
         return diff(d, d.getSource().toString());
     }
 
-    public static GameEngine tree(final VariationTree t, final String title) {
-        return new GameEngine(new DiffTreeApp(
+    public static <L extends Label> GameEngine tree(final VariationTree<L> t, final String title, List<DiffNodeLabelFormat<L>> availableFormats) {
+        return new GameEngine(new DiffTreeApp<>(
                 title,
                 t.toCompletelyUnchangedDiffTree(),
-                DEFAULT_RESOLUTION
+                DEFAULT_RESOLUTION,
+                availableFormats
         ));
     }
 
-    public static GameEngine tree(final VariationTree t) {
+    public static GameEngine tree(final VariationTree<?> t, final String title) {
+        return tree(t, title, DiffTreeApp.DEFAULT_FORMATS());
+    }
+
+    public static GameEngine tree(final VariationTree<?> t) {
         return tree(t, t.source().toString());
     }
 
-    public static GameEngine baddiff(final BadVDiff badVDiff, final String title) {
-        final DiffTree d = badVDiff.diff().toDiffTree(
+    public static <L extends Label> GameEngine baddiff(final BadVDiff<L> badVDiff, final String title, List<DiffNodeLabelFormat<L>> availableFormats) {
+        final DiffTree<L> d = badVDiff.diff().toDiffTree(
             v -> {
                 int from = v.getLineRange().fromInclusive();
                 int to = v.getLineRange().toExclusive();
 
-                return new DiffNode(
+                return new DiffNode<>(
                         badVDiff.coloring().get(v),
                         v.getNodeType(),
                         new DiffLineNumber(from, from, from),
                         new DiffLineNumber(to, to, to),
                         v.getFormula(),
-                        v.getLabelLines()
+                        v.getLabel()
                 );
             }
         );
 
-        return new GameEngine(new DiffTreeApp(
+        return new GameEngine(new DiffTreeApp<>(
                 title,
                 d,
-                DEFAULT_RESOLUTION
+                DEFAULT_RESOLUTION,
+                availableFormats
         ));
     }
 
-    public static GameEngine baddiff(final BadVDiff badVDiff) {
+    public static GameEngine baddiff(final BadVDiff<?> badVDiff, final String title) {
+        return baddiff(badVDiff, title, DiffTreeApp.DEFAULT_FORMATS());
+    }
+
+    public static GameEngine baddiff(final BadVDiff<?> badVDiff) {
         return baddiff(badVDiff, badVDiff.diff().source().toString());
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/show/variation/GraphNodeGraphics.java
+++ b/src/main/java/org/variantsync/diffdetective/show/variation/GraphNodeGraphics.java
@@ -11,7 +11,7 @@ import java.awt.geom.AffineTransform;
 
 public class GraphNodeGraphics extends EntityGraphics {
     //// Represented content
-    final NodeView node;
+    final NodeView<?> node;
 
     //// Rendering values
     double circle_borderwidth_relative = 0.05;
@@ -20,7 +20,7 @@ public class GraphNodeGraphics extends EntityGraphics {
     int textbox_borderarcwidth_absolute = 7;
     Font basic = new Font(null, Font.PLAIN, DiffTreeApp.DEFAULT_FONT_SIZE);
 
-    public GraphNodeGraphics(NodeView node) {
+    public GraphNodeGraphics(NodeView<?> node) {
         this.node = node;
     }
 

--- a/src/main/java/org/variantsync/diffdetective/show/variation/NodeView.java
+++ b/src/main/java/org/variantsync/diffdetective/show/variation/NodeView.java
@@ -1,17 +1,18 @@
 package org.variantsync.diffdetective.show.variation;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.serialize.nodeformat.DiffNodeLabelFormat;
 
 import java.awt.*;
 
-public class NodeView {
-    protected final DiffNode node;
-    private DiffNodeLabelFormat labelFormat;
+public class NodeView<L extends Label> {
+    protected final DiffNode<L> node;
+    private DiffTreeApp<L> formatHolder;
 
-    protected NodeView(DiffNode node, DiffNodeLabelFormat format) {
+    protected NodeView(DiffNode<L> node, DiffTreeApp<L> formatHolder) {
         this.node = node;
-        this.labelFormat = format;
+        this.formatHolder = formatHolder;
     }
 
     public Color borderColor() {
@@ -23,14 +24,10 @@ public class NodeView {
     }
 
     public String nodeLabel() {
-        return labelFormat.toLabel(node);
+        return getLabelFormat().toLabel(node);
     }
 
-    public DiffNodeLabelFormat getLabelFormat() {
-        return labelFormat;
-    }
-
-    public void setLabelFormat(DiffNodeLabelFormat labelFormat) {
-        this.labelFormat = labelFormat;
+    public DiffNodeLabelFormat<? super L> getLabelFormat() {
+        return formatHolder.getLabelFormat();
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/tablegen/MiningResultAccumulator.java
+++ b/src/main/java/org/variantsync/diffdetective/tablegen/MiningResultAccumulator.java
@@ -19,6 +19,7 @@ import org.variantsync.diffdetective.analysis.AutomationResult;
 import org.variantsync.diffdetective.analysis.StatisticsAnalysis;
 import org.variantsync.diffdetective.datasets.DatasetDescription;
 import org.variantsync.diffdetective.datasets.DefaultDatasets;
+import org.variantsync.diffdetective.editclass.proposed.ProposedEditClasses;
 import org.variantsync.diffdetective.metadata.EditClassCount;
 import org.variantsync.diffdetective.metadata.ExplainedFilterSummary;
 import org.variantsync.diffdetective.tablegen.rows.ContentRow;
@@ -26,6 +27,7 @@ import org.variantsync.diffdetective.tablegen.styles.ShortTable;
 import org.variantsync.diffdetective.tablegen.styles.VariabilityShare;
 import org.variantsync.diffdetective.util.IO;
 import org.variantsync.diffdetective.validation.FindMedianCommitTime;
+import org.variantsync.diffdetective.variation.Label;
 
 /** Accumulates multiple {@link AnalysisResult}s of several datasets. */
 public class MiningResultAccumulator {
@@ -49,7 +51,7 @@ public class MiningResultAccumulator {
         for (final Path p : paths) {
             var result = new AnalysisResult();
             result.append(ExplainedFilterSummary.KEY, new ExplainedFilterSummary());
-            result.append(EditClassCount.KEY, new EditClassCount());
+            result.append(EditClassCount.KEY, new EditClassCount(ProposedEditClasses.Instance));
             result.append(StatisticsAnalysis.RESULT, new StatisticsAnalysis.Result());
             result.setFrom(p);
             results.put(p.getParent().getFileName().toString(), result);

--- a/src/main/java/org/variantsync/diffdetective/tablegen/styles/VariabilityShare.java
+++ b/src/main/java/org/variantsync/diffdetective/tablegen/styles/VariabilityShare.java
@@ -1,8 +1,8 @@
 package org.variantsync.diffdetective.tablegen.styles;
 
-import org.variantsync.diffdetective.metadata.EditClassCount;
 import org.variantsync.diffdetective.editclass.EditClass;
 import org.variantsync.diffdetective.editclass.proposed.ProposedEditClasses;
+import org.variantsync.diffdetective.metadata.EditClassCount;
 import org.variantsync.diffdetective.tablegen.Row;
 import org.variantsync.diffdetective.tablegen.TableDefinition;
 import org.variantsync.diffdetective.tablegen.rows.ContentRow;

--- a/src/main/java/org/variantsync/diffdetective/validation/EditClassValidation.java
+++ b/src/main/java/org/variantsync/diffdetective/validation/EditClassValidation.java
@@ -12,6 +12,8 @@ import org.variantsync.diffdetective.metadata.EditClassCount;
 import org.variantsync.diffdetective.mining.formats.DirectedEdgeLabelFormat;
 import org.variantsync.diffdetective.mining.formats.MiningNodeFormat;
 import org.variantsync.diffdetective.mining.formats.ReleaseMiningDiffNodeFormat;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.filter.DiffTreeFilter;
 import org.variantsync.diffdetective.variation.diff.parse.DiffTreeParseOptions;
 import org.variantsync.diffdetective.variation.diff.serialize.GraphFormat;
@@ -36,7 +38,7 @@ public class EditClassValidation implements Analysis.Hooks {
     public static final BiFunction<Repository, Path, Analysis> AnalysisFactory = (repo, repoOutputDir) -> new Analysis(
         "EditClassValidation",
         List.of(
-            new PreprocessingAnalysis(new CutNonEditedSubtrees()),
+            new PreprocessingAnalysis(new CutNonEditedSubtrees<>()),
             new FilterAnalysis(DiffTreeFilter.notEmpty()), // filters unwanted trees
             new EditClassValidation(),
             new StatisticsAnalysis()
@@ -55,7 +57,7 @@ public class EditClassValidation implements Analysis.Hooks {
     /**
      * Returns the edge format that should be used for IO of edges in DiffTrees.
      */
-    private static EdgeLabelFormat EdgeFormat(final MiningNodeFormat nodeFormat) {
+    private static EdgeLabelFormat<DiffLinesLabel> EdgeFormat(final MiningNodeFormat nodeFormat) {
         final EdgeLabelFormat.Direction direction = EdgeLabelFormat.Direction.ParentToChild;
         return new DirectedEdgeLabelFormat(nodeFormat, false, direction);
     }
@@ -63,9 +65,9 @@ public class EditClassValidation implements Analysis.Hooks {
     /**
      * Creates new export options for running the validation on the given repository.
      */
-    public static LineGraphExportOptions ValidationExportOptions(final Repository repository) {
+    public static LineGraphExportOptions<DiffLinesLabel> ValidationExportOptions(final Repository repository) {
         final MiningNodeFormat nodeFormat = NodeFormat();
-        return new LineGraphExportOptions(
+        return new LineGraphExportOptions<DiffLinesLabel>(
                 GraphFormat.DIFFTREE
                 // We have to ensure that all DiffTrees have unique IDs, so use name of changed file and commit hash.
                 , new CommitDiffDiffTreeLabelFormat()
@@ -111,7 +113,7 @@ public class EditClassValidation implements Analysis.Hooks {
 
     @Override
     public void initializeResults(Analysis analysis) {
-        analysis.append(EditClassCount.KEY, new EditClassCount());
+        analysis.append(EditClassCount.KEY, new EditClassCount(ProposedEditClasses.Instance));
     }
 
     @Override

--- a/src/main/java/org/variantsync/diffdetective/variation/DiffLinesLabel.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/DiffLinesLabel.java
@@ -1,0 +1,73 @@
+package org.variantsync.diffdetective.variation;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.variantsync.diffdetective.diff.text.DiffLineNumber;
+import org.variantsync.diffdetective.util.StringUtils;
+import org.variantsync.diffdetective.variation.diff.DiffTree; // For Javadoc
+
+/**
+ * A label consisting of lines with {@link DiffLineNumber line number} information for each line.
+ *
+ * Using this label, a {@link DiffTree} encodes all information (except the original line
+ * ending encoding, i.e. {@code LF} vs {@code CRLF}) necessary to reconstruct the original files
+ * and, when used during construction, the line diff between these files.
+ */
+public class DiffLinesLabel implements Label {
+    private final List<Line> lines;
+
+    public record Line(String content, DiffLineNumber lineNumber) {
+        public static Line withInvalidLineNumber(String content) {
+            return new Line(content, DiffLineNumber.Invalid());
+        }
+    }
+
+    public DiffLinesLabel() {
+        this(new ArrayList<>());
+    }
+
+    public DiffLinesLabel(List<Line> lines) {
+        this.lines = lines;
+    }
+
+    public static DiffLinesLabel withInvalidLineNumbers(List<String> lines) {
+        return new DiffLinesLabel(lines.stream().map(Line::withInvalidLineNumber).toList());
+    }
+
+    public static DiffLinesLabel ofCodeBlock(String codeBlock) {
+        return withInvalidLineNumbers(Arrays.asList(StringUtils.LINEBREAK_REGEX.split(codeBlock, -1)));
+    }
+
+    public void addDiffLine(Line newLine) {
+        lines.add(newLine);
+    }
+
+    public void addDiffLines(List<Line> newLines) {
+        lines.addAll(newLines);
+    }
+
+    public List<Line> getDiffLines() {
+        return lines;
+    }
+
+    @Override
+    public List<String> getLines() {
+        return getDiffLines().stream().map(Line::content).toList();
+    }
+
+    @Override
+    public String toString() {
+        return lines
+            .stream()
+            .map(Line::content)
+            .collect(Collectors.joining(StringUtils.LINEBREAK));
+    }
+
+    @Override
+    public DiffLinesLabel clone() {
+        return new DiffLinesLabel(new ArrayList<>(lines));
+    }
+}

--- a/src/main/java/org/variantsync/diffdetective/variation/Label.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/Label.java
@@ -1,0 +1,14 @@
+package org.variantsync.diffdetective.variation;
+
+import java.util.List;
+
+import org.variantsync.diffdetective.variation.diff.DiffTree; // For Javadoc
+import org.variantsync.diffdetective.variation.tree.VariationTree; // For Javadoc
+
+/**
+ * Base interface for labels of {@link VariationTree}s and {@link DiffTree}s.
+ */
+public interface Label {
+    List<String> getLines();
+    Label clone();
+}

--- a/src/main/java/org/variantsync/diffdetective/variation/LinesLabel.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/LinesLabel.java
@@ -1,0 +1,43 @@
+package org.variantsync.diffdetective.variation;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.variantsync.diffdetective.util.StringUtils;
+
+/**
+ * A label containing a list of lines represented as {@code String}s.
+ */
+public class LinesLabel implements Label {
+    private final List<String> lines;
+
+    public LinesLabel() {
+        this(new ArrayList<>());
+    }
+
+    public LinesLabel(List<String> lines) {
+        this.lines = lines;
+    }
+
+    public static LinesLabel ofCodeBlock(String codeBlock) {
+        return new LinesLabel(Arrays.asList(StringUtils.LINEBREAK_REGEX.split(codeBlock, -1)));
+    }
+
+    public List<String> getLines() {
+        return lines;
+    }
+
+    @Override
+    public String toString() {
+        return lines
+            .stream()
+            .collect(Collectors.joining(StringUtils.LINEBREAK));
+    }
+
+    @Override
+    public LinesLabel clone() {
+        return new LinesLabel(new ArrayList<>(lines));
+    }
+}

--- a/src/main/java/org/variantsync/diffdetective/variation/VariationLabel.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/VariationLabel.java
@@ -1,0 +1,52 @@
+package org.variantsync.diffdetective.variation;
+
+import java.util.List;
+
+import org.variantsync.diffdetective.variation.tree.HasNodeType;
+import org.variantsync.diffdetective.variation.tree.VariationTree; // For Javadoc
+import org.variantsync.functjonal.Cast;
+
+/**
+ * Extends an inner {@link Label}, the object language, with variability, the meta language.
+ *
+ * This class allows encoding of multiple levels of variability in the sense of variation trees of
+ * variation trees. Such higher-order variation trees can be encoded in a single tree structure
+ * because the result of configuring a variation tree is still a tree. In other words: the object
+ * language of a {@code VariationTree<L>} is a tree with labels {@code L}. The trick is that a
+ * variation tree is just a tree with labels {@code VariationLabel<L>}.
+ *
+ * @param <L> the label of the trees (the object language) over which variability is introduced
+ * @see VariationTree
+ */
+public class VariationLabel<L extends Label> implements Label, HasNodeType {
+    private NodeType type;
+    private L innerLabel;
+
+    public VariationLabel(NodeType type, L innerLabel) {
+        this.type = type;
+        this.innerLabel = innerLabel;
+    }
+
+    public L getInnerLabel() {
+        return innerLabel;
+    }
+
+    public void setInnerLabel(L innerLabel) {
+        this.innerLabel = innerLabel;
+    }
+
+    @Override
+    public List<String> getLines() {
+        return innerLabel.getLines();
+    }
+
+    @Override
+    public NodeType getNodeType() {
+        return type;
+    }
+
+    @Override
+    public VariationLabel<L> clone() {
+        return new VariationLabel<L>(type, Cast.unchecked(innerLabel.clone()));
+    }
+}

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/Construction.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/Construction.java
@@ -9,10 +9,12 @@ import org.variantsync.diffdetective.diff.text.DiffLineNumber;
 import org.variantsync.diffdetective.gumtree.DiffTreeAdapter;
 import org.variantsync.diffdetective.gumtree.VariationTreeAdapter;
 import org.variantsync.diffdetective.util.Assert;
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.source.VariationTreeDiffSource;
 import org.variantsync.diffdetective.variation.diff.traverse.DiffTreeTraversal;
 import org.variantsync.diffdetective.variation.tree.VariationNode;
 import org.variantsync.diffdetective.variation.tree.VariationTree;
+import org.variantsync.functjonal.Cast;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,14 +32,14 @@ public class Construction {
      *
      * @see diffUsingMatching(VariationNode, VariationNode, Matcher)
      */
-    public static DiffTree diffUsingMatching(VariationTree before, VariationTree after) {
-        DiffNode root = diffUsingMatching(
+    public static <L extends Label> DiffTree<L> diffUsingMatching(VariationTree<L> before, VariationTree<L> after) {
+        DiffNode<L> root = diffUsingMatching(
             before.root(),
             after.root(),
             Matchers.getInstance().getMatcher()
         );
 
-        return new DiffTree(root, new VariationTreeDiffSource(before.source(), after.source()));
+        return new DiffTree<>(root, new VariationTreeDiffSource(before.source(), after.source()));
     }
 
     /**
@@ -50,9 +52,9 @@ public class Construction {
      * @param after the variation tree after an edit
      * @see diffUsingMatching(DiffNode, VariationNode, Matcher)
      */
-    public static <A extends VariationNode<A>, B extends VariationNode<B>> DiffNode diffUsingMatching(
-        VariationNode<A> before,
-        VariationNode<B> after,
+    public static <A extends VariationNode<A, L>, B extends VariationNode<B, L>, L extends Label> DiffNode<L> diffUsingMatching(
+        VariationNode<A, L> before,
+        VariationNode<B, L> after,
         Matcher matcher
     ) {
         return diffUsingMatching(DiffNode.unchanged(before), after, matcher);
@@ -72,24 +74,24 @@ public class Construction {
      * @param after the variation tree after an edit
      * @see "Constructing Variation Diffs Using Tree Diffing Algorithms"
      */
-    public static <B extends VariationNode<B>> DiffNode diffUsingMatching(
-        DiffNode before,
-        VariationNode<B> after,
+    public static <B extends VariationNode<B, L>, L extends Label> DiffNode<L> diffUsingMatching(
+        DiffNode<L> before,
+        VariationNode<B, L> after,
         Matcher matcher
     ) {
-        var src = new DiffTreeAdapter(before, BEFORE);
-        var dst = new VariationTreeAdapter(after);
+        var src = new DiffTreeAdapter<L>(before, BEFORE);
+        var dst = new VariationTreeAdapter<L>(after);
 
         MappingStore matching = matcher.match(src, dst);
         Assert.assertTrue(matching.has(src, dst));
 
         removeUnmapped(matching, src);
         for (var child : dst.getChildren()) {
-            addUnmapped(matching, src.getDiffNode(), (VariationTreeAdapter)child);
+            addUnmapped(matching, src.getDiffNode(), Cast.unchecked(child));
         }
 
         int[] currentID = new int[1];
-        DiffTreeTraversal.forAll((node) -> {
+        DiffTreeTraversal.<L>forAll((node) -> {
             node.setFromLine(node.getFromLine().withLineNumberInDiff(currentID[0]));
             node.setToLine(node.getToLine().withLineNumberInDiff(currentID[0]));
             ++currentID[0];
@@ -105,11 +107,11 @@ public class Construction {
      * variation tree
      * @param root the variation diff whose before projection is modified
      */
-    private static void removeUnmapped(MappingStore mappings, DiffTreeAdapter root) {
+    private static <L extends Label> void removeUnmapped(MappingStore mappings, DiffTreeAdapter<L> root) {
         for (var node : root.preOrder()) {
             Tree dst = mappings.getDstForSrc(node);
             if (dst == null || !dst.getLabel().equals(node.getLabel())) {
-                var diffNode = ((DiffTreeAdapter)node).getDiffNode();
+                var diffNode = Cast.<Tree, DiffTreeAdapter<L>>unchecked(node).getDiffNode();
                 diffNode.diffType = REM;
                 diffNode.drop(AFTER);
             }
@@ -128,25 +130,25 @@ public class Construction {
      * @param parent the variation diff whose {@code AFTER} projection is modified
      * @param afterNode a desired child of {@code parent}'s {@code AFTER} projection
      */
-    private static void addUnmapped(MappingStore mappings, DiffNode parent, VariationTreeAdapter afterNode) {
-        VariationNode<?> variationNode = afterNode.getVariationNode();
-        DiffNode diffNode;
+    private static <L extends Label> void addUnmapped(MappingStore mappings, DiffNode<L> parent, VariationTreeAdapter<L> afterNode) {
+        VariationNode<?, L> variationNode = afterNode.getVariationNode();
+        DiffNode<L> diffNode;
 
         Tree src = mappings.getSrcForDst(afterNode);
         if (src == null || !src.getLabel().equals(afterNode.getLabel())) {
             int from = variationNode.getLineRange().fromInclusive();
             int to = variationNode.getLineRange().toExclusive();
 
-            diffNode = new DiffNode(
+            diffNode = new DiffNode<L>(
                 ADD,
                 variationNode.getNodeType(),
                 new DiffLineNumber(DiffLineNumber.InvalidLineNumber, from, from),
                 new DiffLineNumber(DiffLineNumber.InvalidLineNumber, to, to),
                 variationNode.getFormula(),
-                variationNode.getLabelLines()
+                Cast.unchecked(variationNode.getLabel().clone())
             );
         } else {
-            diffNode = ((DiffTreeAdapter)src).getDiffNode();
+            diffNode = Cast.<Tree, DiffTreeAdapter<L>>unchecked(src).getDiffNode();
             if (diffNode.getParent(AFTER) != null) {
                 // Always drop and reinsert it because it could have moved.
                 diffNode.drop(AFTER);
@@ -156,7 +158,7 @@ public class Construction {
 
         diffNode.removeChildren(AFTER);
         for (var child : afterNode.getChildren()) {
-            addUnmapped(mappings, diffNode, (VariationTreeAdapter)child);
+            addUnmapped(mappings, diffNode, Cast.unchecked(child));
         }
     }
 
@@ -171,9 +173,9 @@ public class Construction {
      *
      * @see "Constructing Variation Diffs Using Tree Diffing Algorithms"
      */
-    public static DiffNode improveMatching(DiffNode tree, Matcher matcher) {
-        var src = new DiffTreeAdapter(tree, BEFORE);
-        var dst = new DiffTreeAdapter(tree, AFTER);
+    public static <L extends Label> DiffNode<L> improveMatching(DiffNode<L> tree, Matcher matcher) {
+        var src = new DiffTreeAdapter<>(tree, BEFORE);
+        var dst = new DiffTreeAdapter<>(tree, AFTER);
 
         MappingStore matching = new MappingStore(src, dst);
         extractMatching(src, dst, matching);
@@ -182,7 +184,7 @@ public class Construction {
 
         for (var srcNode : src.preOrder()) {
             var dstNode = matching.getDstForSrc(srcNode);
-            var beforeNode = ((DiffTreeAdapter)srcNode).getDiffNode();
+            var beforeNode = Cast.<Tree, DiffTreeAdapter<L>>unchecked(srcNode).getDiffNode();
             if (dstNode == null || !srcNode.getLabel().equals(dstNode.getLabel())) {
                 if (beforeNode.isNon()) {
                     splitNode(beforeNode);
@@ -190,7 +192,7 @@ public class Construction {
 
                 Assert.assertTrue(beforeNode.isRem());
             } else {
-                var afterNode = ((DiffTreeAdapter)dstNode).getDiffNode();
+                var afterNode = Cast.<Tree, DiffTreeAdapter<L>>unchecked(dstNode).getDiffNode();
 
                 if (beforeNode != afterNode) {
                     if (beforeNode.isNon()) {
@@ -223,10 +225,10 @@ public class Construction {
      * @param beforeNode the node to be split
      * @return a copy of {@code beforeNode} existing only after the edit.
      */
-    private static DiffNode splitNode(DiffNode beforeNode) {
+    private static <L extends Label> DiffNode<L> splitNode(DiffNode<L> beforeNode) {
         Assert.assertTrue(beforeNode.isNon());
 
-        DiffNode afterNode = beforeNode.shallowCopy();
+        DiffNode<L> afterNode = beforeNode.shallowCopy();
 
         afterNode.diffType = ADD;
         beforeNode.diffType = REM;
@@ -253,7 +255,7 @@ public class Construction {
      * @param beforeNode the node which is will exist {@code BEFORE} and {@code AFTER} the edit
      * @param afterNode the node which is discarded
      */
-    private static void joinNode(DiffNode beforeNode, DiffNode afterNode) {
+    private static <L extends Label> void joinNode(DiffNode<L> beforeNode, DiffNode<L> afterNode) {
         Assert.assertTrue(beforeNode.isRem());
         Assert.assertTrue(afterNode.isAdd());
 
@@ -275,22 +277,22 @@ public class Construction {
      * {@code src}
      * @param result the destination where the matching between {@code src} and {@code dst} is added
      */
-    private static void extractMatching(
-        DiffTreeAdapter src,
-        DiffTreeAdapter dst,
+    private static <L extends Label> void extractMatching(
+        DiffTreeAdapter<L> src,
+        DiffTreeAdapter<L> dst,
         MappingStore result
     ) {
-        Map<DiffNode, Tree> matching = new HashMap<>();
+        Map<DiffNode<L>, Tree> matching = new HashMap<>();
 
         for (var srcNode : src.preOrder()) {
-            DiffNode diffNode = ((DiffTreeAdapter)srcNode).getDiffNode();
+            DiffNode<L> diffNode = Cast.<Tree, DiffTreeAdapter<L>>unchecked(srcNode).getDiffNode();
             if (diffNode.isNon()) {
                 matching.put(diffNode, srcNode);
             }
         }
 
         for (var dstNode : dst.preOrder()) {
-            DiffNode diffNode = ((DiffTreeAdapter)dstNode).getDiffNode();
+            DiffNode<L> diffNode = Cast.<Tree, DiffTreeAdapter<L>>unchecked(dstNode).getDiffNode();
             if (diffNode.isNon()) {
                 Assert.assertTrue(matching.get(diffNode) != null);
                 result.addMapping(matching.get(diffNode), dstNode);

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/DiffGraph.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/DiffGraph.java
@@ -1,8 +1,10 @@
 package org.variantsync.diffdetective.variation.diff;
 
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.source.DiffTreeSource;
 
 import java.util.Collection;
+
 import static org.variantsync.diffdetective.variation.diff.Time.AFTER;
 import static org.variantsync.diffdetective.variation.diff.Time.BEFORE;
 
@@ -20,7 +22,7 @@ public final class DiffGraph {
     /**
      * Invokes {@link DiffGraph#fromNodes(Collection, DiffTreeSource)} )} with an unknown DiffTreeSource.
      */
-    public static DiffTree fromNodes(final Collection<DiffNode> nodes) {
+    public static DiffTree<DiffLinesLabel> fromNodes(final Collection<DiffNode<DiffLinesLabel>> nodes) {
         return fromNodes(nodes, DiffTreeSource.Unknown);
     }
 
@@ -31,9 +33,8 @@ public final class DiffGraph {
      * @param source the source where the DiffGraph came from.
      * @return A DiffTree representing the DiffGraph with a synthetic root node.
      */
-    public static DiffTree fromNodes(final Collection<DiffNode> nodes, final DiffTreeSource source) {
-        final DiffNode newRoot = DiffNode.createRoot();
-        newRoot.setLabel(DIFFGRAPH_LABEL);
+    public static DiffTree<DiffLinesLabel> fromNodes(final Collection<DiffNode<DiffLinesLabel>> nodes, final DiffTreeSource source) {
+        final DiffNode<DiffLinesLabel> newRoot = DiffNode.createRoot(DiffLinesLabel.ofCodeBlock(DIFFGRAPH_LABEL));
         nodes.stream()
                 .filter(DiffNode::isRoot)
                 .forEach(n ->
@@ -41,6 +42,6 @@ public final class DiffGraph {
                                 () -> newRoot.addChild(n, BEFORE),
                                 () -> newRoot.addChild(n, AFTER)
                         ));
-        return new DiffTree(newRoot, source);
+        return new DiffTree<>(newRoot, source);
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/Projection.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/Projection.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.prop4j.Node;
 import org.variantsync.diffdetective.util.LineRange;
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.NodeType;
 import org.variantsync.diffdetective.variation.tree.VariationNode;
 import org.variantsync.functjonal.list.FilteredMappedListView;
@@ -19,8 +20,8 @@ import org.variantsync.functjonal.list.FilteredMappedListView;
  *
  * @see DiffNode#projection
  */
-public class Projection extends VariationNode<Projection> {
-    private DiffNode backingNode;
+public class Projection<L extends Label> extends VariationNode<Projection<L>, L> {
+    private DiffNode<L> backingNode;
     private Time time;
 
     /**
@@ -32,7 +33,7 @@ public class Projection extends VariationNode<Projection> {
      * @param backingNode the {@link DiffNode} which should be projected
      * @param time which projection this should be
      */
-    Projection(DiffNode backingNode, Time time) {
+    Projection(DiffNode<L> backingNode, Time time) {
         this.backingNode = backingNode;
         this.time = time;
     }
@@ -41,12 +42,12 @@ public class Projection extends VariationNode<Projection> {
         return time;
     }
 
-    public DiffNode getBackingNode() {
+    public DiffNode<L> getBackingNode() {
         return backingNode;
     }
 
     @Override
-    public Projection upCast() {
+    public Projection<L> upCast() {
         return this;
     }
 
@@ -57,7 +58,7 @@ public class Projection extends VariationNode<Projection> {
     }
 
     @Override
-    public Label getLabel() {
+    public L getLabel() {
         return getBackingNode().getLabel();
     }
 
@@ -72,7 +73,7 @@ public class Projection extends VariationNode<Projection> {
     }
 
     @Override
-    public Projection getParent() {
+    public Projection<L> getParent() {
         var parent = getBackingNode().getParent(time);
 
         if (parent == null) {
@@ -84,7 +85,7 @@ public class Projection extends VariationNode<Projection> {
 
 
     @Override
-    public List<Projection> getChildren() {
+    public List<Projection<L>> getChildren() {
         return FilteredMappedListView.map(
             getBackingNode().getChildOrder(time),
             child -> child.projection(time)
@@ -92,17 +93,17 @@ public class Projection extends VariationNode<Projection> {
     }
 
     @Override
-    public void addChild(final Projection child) {
+    public void addChild(final Projection<L> child) {
         getBackingNode().addChild(child.getBackingNode(), time);
     }
 
     @Override
-    public void insertChild(final Projection child, int index) {
+    public void insertChild(final Projection<L> child, int index) {
         getBackingNode().insertChild(child.getBackingNode(), index, time);
     }
 
     @Override
-    public void removeChild(final Projection child) {
+    public void removeChild(final Projection<L> child) {
         getBackingNode().removeChild(child.getBackingNode(), time);
     }
 

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/Projection.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/Projection.java
@@ -54,7 +54,7 @@ public class Projection<L extends Label> extends VariationNode<Projection<L>, L>
 
     @Override
     public NodeType getNodeType() {
-        return getBackingNode().nodeType;
+        return getBackingNode().getNodeType();
     }
 
     @Override

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/filter/DiffTreeFilter.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/filter/DiffTreeFilter.java
@@ -1,5 +1,6 @@
 package org.variantsync.diffdetective.variation.diff.filter;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 
@@ -11,18 +12,18 @@ import static org.variantsync.diffdetective.editclass.proposed.ProposedEditClass
  * Iff the condition returns true, the DiffTree should be considered.
  * @author Paul Bittner
  */
-public final class DiffTreeFilter {
+public final class DiffTreeFilter<L extends Label> {
     /**
      * Returns a tagged predicate that always returns true and is tagged with the given metadata.
      */
-    public static <T> TaggedPredicate<T, DiffTree> Any(final T metadata) {
+    public static <T, L extends Label> TaggedPredicate<T, DiffTree<? extends L>> Any(final T metadata) {
         return TaggedPredicate.Any(metadata);
     }
 
     /**
      * Returns a tagged predicate that always returns true and is tagged with the String {@code "any"}.
      */
-    public static TaggedPredicate<String, DiffTree> Any() {
+    public static <L extends Label> TaggedPredicate<String, DiffTree<? extends L>> Any() {
         return Any("any");
     }
 
@@ -31,7 +32,7 @@ public final class DiffTreeFilter {
      * the DiffTree has more than one artifact node ({@link DiffNode#isArtifact()}.
      * The predicate is tagged with a String description of the predicate.
      */
-    public static TaggedPredicate<String, DiffTree> moreThanOneArtifactNode() {
+    public static <L extends Label> TaggedPredicate<String, DiffTree<? extends L>> moreThanOneArtifactNode() {
         return new TaggedPredicate<>(
                 "has more than one artifact node",
                 tree -> tree.count(DiffNode::isArtifact) > 1
@@ -43,7 +44,7 @@ public final class DiffTreeFilter {
      * the DiffTree is not empty ({@link DiffTree#isEmpty()}.
      * The predicate is tagged with a String description of the predicate.
      */
-    public static TaggedPredicate<String, DiffTree> notEmpty() {
+    public static <L extends Label> TaggedPredicate<String, DiffTree<? extends L>> notEmpty() {
         return new TaggedPredicate<>(
             "is not empty",
                 tree -> !tree.isEmpty()
@@ -55,7 +56,7 @@ public final class DiffTreeFilter {
      * the DiffTree is {@link DiffTree#isConsistent() consistent}.
      * The predicate is tagged with a String description of the predicate.
      */
-    public static TaggedPredicate<String, DiffTree> consistent() {
+    public static <L extends Label> TaggedPredicate<String, DiffTree<? extends L>> consistent() {
         return new TaggedPredicate<>(
                 "is consistent",
                 tree -> tree.isConsistent().isSuccess()
@@ -71,7 +72,7 @@ public final class DiffTreeFilter {
      * {@link org.variantsync.diffdetective.editclass.proposed.ProposedEditClasses#Untouched}.
      * The predicate is tagged with a String description of the predicate.
      */
-    public static TaggedPredicate<String, DiffTree> hasAtLeastOneEditToVariability() {
+    public static <L extends Label> TaggedPredicate<String, DiffTree<? extends L>> hasAtLeastOneEditToVariability() {
         return new TaggedPredicate<>(
                 "has edits to variability",
                 tree -> tree.anyMatch(n ->

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/filter/DuplicateDiffTreeFilter.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/filter/DuplicateDiffTreeFilter.java
@@ -1,5 +1,6 @@
 package org.variantsync.diffdetective.variation.diff.filter;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 
 import java.util.ArrayList;
@@ -10,14 +11,14 @@ import java.util.function.BiFunction;
  * Filters all duplicates in a list of DiffTrees regarding isomorphism.
  * @author Paul Bittner
  */
-public class DuplicateDiffTreeFilter {
-    private final BiFunction<DiffTree, DiffTree, Boolean> equality;
+public class DuplicateDiffTreeFilter<L extends Label> {
+    private final BiFunction<DiffTree<L>, DiffTree<L>, Boolean> equality;
 
     /**
      * Creates a new duplication filter that uses the given predicate to determine equality of DiffTrees.
      * @param equalityCondition Predicate that determines equality of DiffTrees.
      */
-    public DuplicateDiffTreeFilter(final BiFunction<DiffTree, DiffTree, Boolean> equalityCondition) {
+    public DuplicateDiffTreeFilter(final BiFunction<DiffTree<L>, DiffTree<L>, Boolean> equalityCondition) {
         this.equality = equalityCondition;
     }
 
@@ -26,10 +27,10 @@ public class DuplicateDiffTreeFilter {
      * @param treesWithDuplicates List of DiffTress that may contain duplicate trees.
      * @return A list without duplicates. Every tree in the returned list was contained in the input list.
      */
-    public List<DiffTree> filterDuplicates(final List<DiffTree> treesWithDuplicates) {
-        final List<DiffTree> distinct = new ArrayList<>(treesWithDuplicates.size());
+    public List<DiffTree<L>> filterDuplicates(final List<DiffTree<L>> treesWithDuplicates) {
+        final List<DiffTree<L>> distinct = new ArrayList<>(treesWithDuplicates.size());
 
-        for (final DiffTree candidate : treesWithDuplicates) {
+        for (final DiffTree<L> candidate : treesWithDuplicates) {
             if (distinct.stream().noneMatch(t -> equality.apply(candidate, t))) {
                 distinct.add(candidate);
             }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/filter/ExplainedFilter.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/filter/ExplainedFilter.java
@@ -94,13 +94,13 @@ public class ExplainedFilter<T> implements Predicate<T> {
         }
     }
 
-    private final List<TaggedPredicate<Explanation, T>> filters;
+    private final List<TaggedPredicate<Explanation, ? super T>> filters;
 
     /**
      * Creates an ExplainedFilter by conjunction of all given filters.
      * @param namedFilters Filters to compose. Each filter has to be explained by a (unique) name.
      */
-    public ExplainedFilter(final Stream<TaggedPredicate<String, T>> namedFilters) {
+    public ExplainedFilter(final Stream<TaggedPredicate<String, ? super T>> namedFilters) {
         this.filters = namedFilters.map(
                 filter -> filter.map(Explanation::new)
         ).collect(Collectors.toList());
@@ -110,7 +110,7 @@ public class ExplainedFilter<T> implements Predicate<T> {
      * Same as {@link ExplainedFilter#ExplainedFilter(Stream)} but with variadic arguments.
      */
     @SafeVarargs
-    public ExplainedFilter(final TaggedPredicate<String, T>... filters) {
+    public ExplainedFilter(final TaggedPredicate<String, ? super T>... filters) {
         this(Arrays.stream(filters));
     }
 
@@ -124,7 +124,7 @@ public class ExplainedFilter<T> implements Predicate<T> {
 
     @Override
     public boolean test(final T element) {
-        for (final TaggedPredicate<Explanation, T> filter : filters) {
+        for (final TaggedPredicate<Explanation, ? super T> filter : filters) {
             if (!filter.condition().test(element)) {
                 filter.tag().hit();
                 return false;
@@ -148,7 +148,7 @@ public class ExplainedFilter<T> implements Predicate<T> {
      * Returns all sub-filters whose filter hits are recorded.
      * @return
      */
-    public List<TaggedPredicate<Explanation, T>> getFilters() {
+    public List<TaggedPredicate<Explanation, ? super T>> getFilters() {
         return filters;
     }
 

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/graph/FormalDiffGraph.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/graph/FormalDiffGraph.java
@@ -1,6 +1,7 @@
 package org.variantsync.diffdetective.variation.diff.graph;
 
 import org.variantsync.diffdetective.util.StringUtils;
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.Time;
@@ -17,11 +18,11 @@ import java.util.*;
  *
  * @author Paul Bittner
  */
-public record FormalDiffGraph(
-        Set<DiffNode> nodes,
-        Set<Edge> edges
+public record FormalDiffGraph<L extends Label>(
+        Set<DiffNode<L>> nodes,
+        Set<Edge<L>> edges
 ) {
-    public record Edge (DiffNode child, DiffNode parent, Time time) {
+    public record Edge<L extends Label>(DiffNode<L> child, DiffNode<L> parent, Time time) {
     }
 
     /**
@@ -32,31 +33,31 @@ public record FormalDiffGraph(
      * @param d The DiffTree to view as a list of nodes and edges.
      * @return the graph view
      */
-    public static FormalDiffGraph fromDiffTree(final DiffTree d) {
-        final Set<DiffNode> nodes = new HashSet<>();
-        final Set<Edge> edges = new HashSet<>();
+    public static <L extends Label> FormalDiffGraph<L> fromDiffTree(final DiffTree<L> d) {
+        final Set<DiffNode<L>> nodes = new HashSet<>();
+        final Set<Edge<L>> edges = new HashSet<>();
 
         d.forAll(n -> {
            nodes.add(n);
            if (!n.isRoot()) {
                n.getDiffType().forAllTimesOfExistence(
-                       time -> edges.add(new Edge(n, n.getParent(time), time))
+                       time -> edges.add(new Edge<>(n, n.getParent(time), time))
                );
            }
         });
 
-        return new FormalDiffGraph(nodes, edges);
+        return new FormalDiffGraph<>(nodes, edges);
     }
 
     @Override
     public String toString() {
         final StringBuilder b = new StringBuilder();
 
-        for (final DiffNode v : nodes) {
+        for (final DiffNode<L> v : nodes) {
             b.append(v.getID()).append(": ").append(v).append(StringUtils.LINEBREAK);
         }
 
-        for (final Edge e : edges) {
+        for (final var e : edges) {
             b
                     .append(e.child().getID())
                     .append(" --")

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/parse/DiffTreeParseOptions.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/parse/DiffTreeParseOptions.java
@@ -1,6 +1,5 @@
 package org.variantsync.diffdetective.variation.diff.parse;
 
-import org.variantsync.diffdetective.datasets.PatchDiffParseOptions;
 import org.variantsync.diffdetective.feature.CPPAnnotationParser;
 
 /**

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/parse/LogicalLine.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/parse/LogicalLine.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import org.variantsync.diffdetective.diff.text.DiffLineNumber;
 import org.variantsync.diffdetective.util.Assert;
-import org.variantsync.diffdetective.variation.diff.DiffNode;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 
 /**
  * A logical line consisting of multiple physical lines of a text file joined by line continuations.
@@ -18,7 +18,7 @@ import org.variantsync.diffdetective.variation.diff.DiffNode;
  * @author Benjamin Moosherr
  */
 class LogicalLine {
-    private List<DiffNode.Label.Line> lines;
+    private List<DiffLinesLabel.Line> lines;
     private boolean isContinued;
     private DiffLineNumber startLineNumber;
 
@@ -51,7 +51,7 @@ class LogicalLine {
         if (!hasStarted()) {
             startLineNumber = lineNumber;
         }
-        lines.add(new DiffNode.Label.Line(line, lineNumber));
+        lines.add(new DiffLinesLabel.Line(line, lineNumber));
         isContinued = line.endsWith("\\");
     }
 
@@ -82,7 +82,7 @@ class LogicalLine {
      * Returns all physical lines {@link consume}d for the current logical line.
      * The backslashes of line continuations are still part of the strings.
      */
-    public List<DiffNode.Label.Line> getLines() {
+    public List<DiffLinesLabel.Line> getLines() {
         return lines;
     }
 

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/render/PatchDiffRenderer.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/render/PatchDiffRenderer.java
@@ -4,6 +4,7 @@ import org.tinylog.Logger;
 import org.variantsync.diffdetective.diff.git.GitPatch;
 import org.variantsync.diffdetective.diff.git.PatchDiff;
 import org.variantsync.diffdetective.util.IO;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.serialize.LineGraphConstants;
 import org.variantsync.diffdetective.variation.diff.serialize.LineGraphExportOptions;
@@ -25,18 +26,18 @@ public class PatchDiffRenderer {
      * Default RenderOptions for debug rendering of DiffTrees
      * relevant to the occurrence of an error.
      */
-    public static final RenderOptions ErrorDiffTreeRenderOptions = new RenderOptions.Builder()
+    public static final RenderOptions<DiffLinesLabel> ErrorDiffTreeRenderOptions = new RenderOptions.Builder<DiffLinesLabel>()
 //            .setNodeFormat(new MappingsDiffNodeFormat())
-            .setNodeFormat(new TypeDiffNodeFormat())
+            .setNodeFormat(new TypeDiffNodeFormat<>())
             .setDpi(2000)
-    		.setNodesize(RenderOptions.DEFAULT.nodesize()/30)
-    		.setEdgesize(0.2*RenderOptions.DEFAULT.edgesize())
-    		.setArrowsize(RenderOptions.DEFAULT.arrowsize()/5)
-    		.setFontsize(2)
-    		.build();
+            .setNodesize(RenderOptions.DEFAULT().nodesize()/30)
+            .setEdgesize(0.2*RenderOptions.DEFAULT().edgesize())
+            .setArrowsize(RenderOptions.DEFAULT().arrowsize()/5)
+            .setFontsize(2)
+            .build();
 
     private final DiffTreeRenderer renderer;
-    private final RenderOptions options;
+    private final RenderOptions<? super DiffLinesLabel> options;
 
     /**
      * Creates a PatchDiffRenderer wrapping the given renderer and rendering patches
@@ -44,7 +45,7 @@ public class PatchDiffRenderer {
      * @param renderer The renderer to use when rendering PatchDiffs.
      * @param options Options to use for all render calls.
      */
-    public PatchDiffRenderer(final DiffTreeRenderer renderer, RenderOptions options) {
+    public PatchDiffRenderer(final DiffTreeRenderer renderer, RenderOptions<? super DiffLinesLabel> options) {
         this.renderer = renderer;
         this.options = options;
     }
@@ -76,7 +77,7 @@ public class PatchDiffRenderer {
      * @param patch The patch from which the given tree was created.
      * @param outputDirectory The directory to which the rendered image should be written.
      */
-    public void render(final DiffTree diffTree, final GitPatch patch, final Path outputDirectory) {
+    public void render(final DiffTree<? extends DiffLinesLabel> diffTree, final GitPatch patch, final Path outputDirectory) {
         renderer.render(diffTree, patch, outputDirectory, options);
         try {
             IO.write(outputDirectory.resolve(

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/render/RenderOptions.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/render/RenderOptions.java
@@ -1,5 +1,6 @@
 package org.variantsync.diffdetective.variation.diff.render;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.serialize.GraphFormat;
 import org.variantsync.diffdetective.variation.diff.serialize.LineGraphExportOptions;
 import org.variantsync.diffdetective.variation.diff.serialize.edgeformat.DefaultEdgeLabelFormat;
@@ -32,11 +33,11 @@ import java.util.List;
  *
  * @author Paul Bittner, Kevin Jedelhauser
  */
-public record RenderOptions(
+public record RenderOptions<L extends Label>(
 		GraphFormat format,
 		DiffTreeLabelFormat treeFormat,
-		DiffNodeLabelFormat nodeFormat,
-		EdgeLabelFormat edgeFormat,
+		DiffNodeLabelFormat<? super L> nodeFormat,
+		EdgeLabelFormat<? super L> edgeFormat,
 		boolean cleanUpTemporaryFiles,
 		int dpi,
 		int nodesize,
@@ -49,16 +50,18 @@ public record RenderOptions(
 	/**
 	 * Default options.
 	 */
-	public static RenderOptions DEFAULT = new Builder().build();
+	public static <L extends Label> RenderOptions<L> DEFAULT() {
+		return new Builder<L>().build();
+	}
 
 	/**
 	 * Builder for {@link RenderOptions}.
 	 */
-	public static class Builder {
+	public static class Builder<L extends Label> {
 		private GraphFormat format;
 		private DiffTreeLabelFormat treeParser;
-		private DiffNodeLabelFormat nodeParser;
-		private EdgeLabelFormat edgeParser;
+		private DiffNodeLabelFormat<? super L> nodeParser;
+		private EdgeLabelFormat<? super L> edgeParser;
 		private boolean cleanUpTemporaryFiles;
 		private int dpi;
 		private int nodesize;
@@ -74,8 +77,8 @@ public record RenderOptions(
 		public Builder() {
 			format = GraphFormat.DIFFTREE;
 			treeParser = new CommitDiffDiffTreeLabelFormat();
-			nodeParser = new DebugDiffNodeFormat();
-			edgeParser = new DefaultEdgeLabelFormat();
+			nodeParser = new DebugDiffNodeFormat<>();
+			edgeParser = new DefaultEdgeLabelFormat<>();
 			cleanUpTemporaryFiles = true;
 			dpi = 300;
 			nodesize = 700;
@@ -91,8 +94,8 @@ public record RenderOptions(
 		 * 
 		 * @return {@link RenderOptions} with this builder's configured settings.
 		 */
-		public RenderOptions build() {
-			return new RenderOptions(
+		public RenderOptions<L> build() {
+			return new RenderOptions<>(
 					format, 
 					treeParser, 
 					nodeParser, 
@@ -110,7 +113,7 @@ public record RenderOptions(
 		/**
 		 * @see RenderOptions#format
 		 */
-		public Builder setGraphFormat(GraphFormat format) {
+		public Builder<L> setGraphFormat(GraphFormat format) {
 			this.format = format;
 			return this;
 		}
@@ -118,7 +121,7 @@ public record RenderOptions(
 		/**
 		 * @see RenderOptions#treeFormat
 		 */
-		public Builder setTreeFormat(DiffTreeLabelFormat treeFormat) {
+		public Builder<L> setTreeFormat(DiffTreeLabelFormat treeFormat) {
 			this.treeParser = treeFormat;
 			return this;
 		}
@@ -126,7 +129,7 @@ public record RenderOptions(
 		/**
 		 * @see RenderOptions#nodeFormat
 		 */
-		public Builder setNodeFormat(DiffNodeLabelFormat nodeFormat) {
+		public Builder<L> setNodeFormat(DiffNodeLabelFormat<? super L> nodeFormat) {
 			this.nodeParser = nodeFormat;
 			return this;
 		}
@@ -134,7 +137,7 @@ public record RenderOptions(
 		/**
 		 * @see RenderOptions#edgeFormat
 		 */
-		public Builder setEdgeFormat(EdgeLabelFormat edgeFormat) {
+		public Builder<L> setEdgeFormat(EdgeLabelFormat<? super L> edgeFormat) {
 			this.edgeParser = edgeFormat;
 			return this;
 		}
@@ -142,7 +145,7 @@ public record RenderOptions(
 		/**
 		 * @see RenderOptions#cleanUpTemporaryFiles
 		 */
-		public Builder setCleanUpTemporaryFiles(boolean cleanUpTemporaryFiles) {
+		public Builder<L> setCleanUpTemporaryFiles(boolean cleanUpTemporaryFiles) {
 			this.cleanUpTemporaryFiles = cleanUpTemporaryFiles;
 			return this;
 		}
@@ -150,7 +153,7 @@ public record RenderOptions(
 		/**
 		 * @see RenderOptions#dpi
 		 */
-		public Builder setDpi(int dpi) {
+		public Builder<L> setDpi(int dpi) {
 			this.dpi = dpi;
 			return this;
 		}
@@ -158,7 +161,7 @@ public record RenderOptions(
 		/**
 		 * @see RenderOptions#nodesize
 		 */
-		public Builder setNodesize(int nodesize) {
+		public Builder<L> setNodesize(int nodesize) {
 			this.nodesize = nodesize;
 			return this;
 		}
@@ -166,7 +169,7 @@ public record RenderOptions(
 		/**
 		 * @see RenderOptions#edgesize
 		 */
-		public Builder setEdgesize(double edgesize) {
+		public Builder<L> setEdgesize(double edgesize) {
 			this.edgesize = edgesize;
 			return this;
 		}
@@ -174,7 +177,7 @@ public record RenderOptions(
 		/**
 		 * @see RenderOptions#arrowsize
 		 */
-		public Builder setArrowsize(int arrowsize) {
+		public Builder<L> setArrowsize(int arrowsize) {
 			this.arrowsize = arrowsize;
 			return this;
 		}
@@ -182,7 +185,7 @@ public record RenderOptions(
 		/**
 		 * @see RenderOptions#fontsize
 		 */
-		public Builder setFontsize(int fontsize) {
+		public Builder<L> setFontsize(int fontsize) {
 			this.fontsize = fontsize;
 			return this;
 		}
@@ -190,7 +193,7 @@ public record RenderOptions(
 		/**
 		 * @see RenderOptions#withlabels
 		 */
-		public Builder setWithlabels(boolean withlabels) {
+		public Builder<L> setWithlabels(boolean withlabels) {
 			this.withlabels = withlabels;
 			return this;
 		}
@@ -199,7 +202,7 @@ public record RenderOptions(
 		 * Resets the extra arguments to the given list.
 		 * @see RenderOptions#extraArguments
 		 */
-		public Builder setExtraArguments(List<String> extraArguments) {
+		public Builder<L> setExtraArguments(List<String> extraArguments) {
 			this.extraArguments = new ArrayList<>(extraArguments);
 			return this;
 		}
@@ -208,7 +211,7 @@ public record RenderOptions(
 		 * Adds further arguments to the already set extra arguments.
 		 * @see RenderOptions#extraArguments
 		 */
-		public Builder addExtraArguments(String... args) {
+		public Builder<L> addExtraArguments(String... args) {
 			// add new list arguments to already existing arguments
             this.extraArguments.addAll(List.of(args));
 			return this;
@@ -221,7 +224,7 @@ public record RenderOptions(
 	 * Linegraph options are a subset of render options.
 	 * @return Options for linegraph export consistent to this RenderOptions.
 	 */
-	public LineGraphExportOptions toLineGraphOptions() {
-		return new LineGraphExportOptions(format(), treeFormat(), nodeFormat(), edgeFormat());
+	public LineGraphExportOptions<L> toLineGraphOptions() {
+		return new LineGraphExportOptions<L>(format(), treeFormat(), nodeFormat(), edgeFormat());
 	}
 }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/Exporter.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/Exporter.java
@@ -2,6 +2,8 @@ package org.variantsync.diffdetective.variation.diff.serialize;
 
 import java.io.IOException;
 import java.io.OutputStream;
+
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 
 /**
@@ -10,7 +12,7 @@ import org.variantsync.diffdetective.variation.diff.DiffTree;
  *
  * @author Benjamin Moosherr
  */
-public interface Exporter {
+public interface Exporter<L extends Label> {
     /**
      * Export a {@code diffTree} into {@code destination}.
      *
@@ -23,5 +25,5 @@ public interface Exporter {
      * @param diffTree to be exported
      * @param destination where the result should be written
      */
-    void exportDiffTree(DiffTree diffTree, OutputStream destination) throws IOException;
+    <La extends L> void exportDiffTree(DiffTree<La> diffTree, OutputStream destination) throws IOException;
 }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/Format.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/Format.java
@@ -1,5 +1,6 @@
 package org.variantsync.diffdetective.variation.diff.serialize;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.serialize.edgeformat.EdgeLabelFormat;
@@ -21,20 +22,20 @@ import static org.variantsync.diffdetective.variation.diff.Time.BEFORE;
  * {@code Format}.
  * </ul>
  */
-public class Format {
-    private final DiffNodeLabelFormat nodeFormat;
-    private final EdgeLabelFormat edgeFormat;
+public class Format<L extends Label> {
+    private final DiffNodeLabelFormat<? super L> nodeFormat;
+    private final EdgeLabelFormat<? super L> edgeFormat;
 
-    public Format(DiffNodeLabelFormat nodeFormat, EdgeLabelFormat edgeFormat) {
+    public Format(DiffNodeLabelFormat<? super L> nodeFormat, EdgeLabelFormat<? super L> edgeFormat) {
         this.nodeFormat = nodeFormat;
         this.edgeFormat = edgeFormat;
     }
 
-    public DiffNodeLabelFormat getNodeFormat() {
+    public DiffNodeLabelFormat<? super L> getNodeFormat() {
         return nodeFormat;
     }
 
-    public EdgeLabelFormat getEdgeFormat() {
+    public EdgeLabelFormat<? super L> getEdgeFormat() {
         return edgeFormat;
     }
 
@@ -49,7 +50,7 @@ public class Format {
      * @param diffTree to be exported
      * @param callback is called for each node
      */
-    public void forEachNode(DiffTree diffTree, Consumer<DiffNode> callback) {
+    public <La extends L> void forEachNode(DiffTree<La> diffTree, Consumer<DiffNode<La>> callback) {
         diffTree.forAll(callback);
     }
 
@@ -65,7 +66,7 @@ public class Format {
      * @param diffTree to be exported
      * @param callback is called for each unique edge
      */
-    public void forEachEdge(DiffTree diffTree, Consumer<StyledEdge> callback) {
+    public <La extends L> void forEachEdge(DiffTree<La> diffTree, Consumer<StyledEdge<La>> callback) {
         diffTree.forAll((node) -> {
             var beforeParent = node.getParent(BEFORE);
             var afterParent = node.getParent(AFTER);
@@ -95,13 +96,13 @@ public class Format {
      * @param style the export style of the constructed edge
      * @param callback the consumer which is called with the resulting {@link StyledEdge}
      */
-    protected void sortedEdgeWithLabel(
-            DiffNode originalFrom,
-            DiffNode originalTo,
+    protected <La extends L> void sortedEdgeWithLabel(
+            DiffNode<La> originalFrom,
+            DiffNode<La> originalTo,
             StyledEdge.Style style,
-            Consumer<StyledEdge> callback
+            Consumer<StyledEdge<La>> callback
     ) {
         var edge = edgeFormat.getEdgeDirection().sort(originalFrom, originalTo);
-        callback.accept(new StyledEdge(edge.first(), edge.second(), style));
+        callback.accept(new StyledEdge<>(edge.first(), edge.second(), style));
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/LineGraphExport.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/LineGraphExport.java
@@ -11,6 +11,8 @@ import org.variantsync.diffdetective.diff.git.CommitDiff;
 import org.variantsync.diffdetective.diff.git.PatchDiff;
 import org.variantsync.diffdetective.metadata.Metadata;
 import org.variantsync.diffdetective.util.StringUtils;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.source.DiffTreeSource;
 import org.variantsync.functjonal.category.InplaceSemigroup;
@@ -72,8 +74,8 @@ public final class LineGraphExport {
      * @param options Configuration options for the export, such as the format used for node and edge labels.
      * @return A pair holding some debug information and the produced linegraph as a string.
      */
-    public static DiffTreeSerializeDebugData toLineGraphFormat(final DiffTree diffTree, final LineGraphExportOptions options, OutputStream destination) throws IOException {
-        final var exporter = new LineGraphExporter(options);
+    public static <L extends Label> DiffTreeSerializeDebugData toLineGraphFormat(final DiffTree<? extends L> diffTree, final LineGraphExportOptions<? super L> options, OutputStream destination) throws IOException {
+        final var exporter = new LineGraphExporter<L>(options);
         exporter.exportDiffTree(diffTree, destination);
         return exporter.getDebugData();
     }
@@ -84,10 +86,10 @@ public final class LineGraphExport {
      * @param options Configuration options for the export, such as the format used for node and edge labels.
      * @return A pair of (1) metadata about the exported DiffTrees, and (2) the produced linegraph as String.
      */
-    public static Statistic toLineGraphFormat(final Iterable<DiffTree> trees, final LineGraphExportOptions options, OutputStream destination) throws IOException {
+    public static <L extends Label> Statistic toLineGraphFormat(final Iterable<DiffTree<L>> trees, final LineGraphExportOptions<? super L> options, OutputStream destination) throws IOException {
         final var result = new Statistic();
 
-        for (final DiffTree t : trees) {
+        for (final DiffTree<? extends L> t : trees) {
             destination.write(lineGraphHeader(t.getSource(), options).getBytes());
             result.debugData.append(toLineGraphFormat(t, options, destination));
             destination.write(lineGraphFooter().getBytes());
@@ -106,7 +108,7 @@ public final class LineGraphExport {
      * @param destination where the resulting line graph is written
      * @return The number of the next diff tree to export (updated value of treeCounter).
      */
-    public static Statistic toLineGraphFormat(final CommitDiff commitDiff, LineGraphExportOptions options, OutputStream destination) throws IOException {
+    public static Statistic toLineGraphFormat(final CommitDiff commitDiff, LineGraphExportOptions<? super DiffLinesLabel> options, OutputStream destination) throws IOException {
         final var result = new Statistic();
 
         for (final PatchDiff patchDiff : commitDiff.getPatchDiffs()) {
@@ -130,7 +132,7 @@ public final class LineGraphExport {
      * @param destination where the resulting line graph is written
      * @return The number of the next diff tree to export (updated value of treeCounter).
      */
-    public static Statistic toLineGraphFormat(final PatchDiff patch, final LineGraphExportOptions options, OutputStream destination) throws IOException {
+    public static Statistic toLineGraphFormat(final PatchDiff patch, final LineGraphExportOptions<? super DiffLinesLabel> options, OutputStream destination) throws IOException {
         final var result = new Statistic();
 
         if (patch.isValid()) {
@@ -158,7 +160,7 @@ public final class LineGraphExport {
      * @param nodesAndEdges Result from {@link #toLineGraphFormat(DiffTree, LineGraphExportOptions, OutputStream)}. Holds all nodes and edges in linegraph format, separated by a newline each.
      * @param options {@link LineGraphExportOptions} used to determine the treeFormat for the header.
      */
-    private static String lineGraphHeader(final DiffTreeSource source, final LineGraphExportOptions options) {
+    private static String lineGraphHeader(final DiffTreeSource source, final LineGraphExportOptions<?> options) {
         return options.treeFormat().toLineGraphLine(source) + StringUtils.LINEBREAK;
     }
 

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/LineGraphExportOptions.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/LineGraphExportOptions.java
@@ -2,13 +2,13 @@ package org.variantsync.diffdetective.variation.diff.serialize;
 
 import org.tinylog.Logger;
 import org.variantsync.diffdetective.diff.git.PatchDiff;
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.render.DiffTreeRenderer;
 import org.variantsync.diffdetective.variation.diff.render.PatchDiffRenderer;
 import org.variantsync.diffdetective.variation.diff.serialize.edgeformat.EdgeLabelFormat;
 import org.variantsync.diffdetective.variation.diff.serialize.nodeformat.DiffNodeLabelFormat;
 import org.variantsync.diffdetective.variation.diff.serialize.treeformat.DiffTreeLabelFormat;
-import org.variantsync.diffdetective.variation.diff.transform.DiffTreeTransformer;
 
 import java.nio.file.Path;
 import java.util.function.BiConsumer;
@@ -23,17 +23,17 @@ import java.util.function.BiConsumer;
  * @param onError Callback that is invoked when an error occurs.
  * @author Paul Bittner
  */
-public record LineGraphExportOptions(
+public record LineGraphExportOptions<L extends Label>(
         GraphFormat graphFormat,
-		DiffTreeLabelFormat treeFormat,
-		DiffNodeLabelFormat nodeFormat,
-        EdgeLabelFormat edgeFormat,
+        DiffTreeLabelFormat treeFormat,
+        DiffNodeLabelFormat<? super L> nodeFormat,
+        EdgeLabelFormat<? super L> edgeFormat,
         BiConsumer<PatchDiff, Exception> onError) {
 
     /**
      * Creates a export options with a neutral filter (that accepts all trees), no transformers, and that logs errors.
      */
-    public LineGraphExportOptions(GraphFormat graphFormat, DiffTreeLabelFormat treeFormat, DiffNodeLabelFormat nodeFormat, EdgeLabelFormat edgeFormat) {
+    public LineGraphExportOptions(GraphFormat graphFormat, DiffTreeLabelFormat treeFormat, DiffNodeLabelFormat<? super L> nodeFormat, EdgeLabelFormat<? super L> edgeFormat) {
         this(graphFormat, treeFormat, nodeFormat, edgeFormat, LogError());
     }
 
@@ -43,7 +43,7 @@ public record LineGraphExportOptions(
      * with all formats from the given import options.
      * @param importOptions The import options to convert to export options.
      */
-    public LineGraphExportOptions(final LineGraphImportOptions importOptions) {
+    public LineGraphExportOptions(final LineGraphImportOptions<? super L> importOptions) {
         this(
                 importOptions.graphFormat(),
                 importOptions.treeFormat(),

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/LineGraphExporter.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/LineGraphExporter.java
@@ -3,23 +3,24 @@ package org.variantsync.diffdetective.variation.diff.serialize;
 import java.io.OutputStream;
 import java.io.PrintStream;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.functjonal.Functjonal;
 
 /**
  * Exporter that converts a single DiffTree's nodes and edges to linegraph.
  */
-public class LineGraphExporter implements Exporter {
-    private final Format format;
+public class LineGraphExporter<L extends Label> implements Exporter<L> {
+    private final Format<? super L> format;
     private final DiffTreeSerializeDebugData debugData;
 
-    public LineGraphExporter(Format format) {
+    public LineGraphExporter(Format<? super L> format) {
         this.format = format;
         this.debugData = new DiffTreeSerializeDebugData();
     }
 
-    public LineGraphExporter(LineGraphExportOptions options) {
-        this(new Format(options.nodeFormat(), options.edgeFormat()));
+    public LineGraphExporter(LineGraphExportOptions<? super L> options) {
+        this(new Format<L>(options.nodeFormat(), options.edgeFormat()));
     }
 
     /**
@@ -29,7 +30,7 @@ public class LineGraphExporter implements Exporter {
      * @param destination where the result should be written
      */
     @Override
-    public void exportDiffTree(DiffTree diffTree, OutputStream destination) {
+    public <La extends L> void exportDiffTree(DiffTree<La> diffTree, OutputStream destination) {
         var output = new PrintStream(destination);
         format.forEachNode(diffTree, (node) -> {
             switch (node.diffType) {

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/LineGraphImport.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/LineGraphImport.java
@@ -144,7 +144,7 @@ public class LineGraphImport {
                     if (root != null) {
                         throw new RuntimeException("Not a DiffTree: Got more than one root! Got \"" + root + "\" and \"" + v + "\"!");
                     }
-                    if (v.nodeType == NodeType.IF) {
+                    if (v.getNodeType() == NodeType.IF) {
                         root = v;
                     } else {
                         throw new RuntimeException("Not a DiffTree but a DiffGraph: The node \"" + v + "\" is not labeled as IF but has no parents!");
@@ -156,7 +156,7 @@ public class LineGraphImport {
                 throw new RuntimeException("Not a DiffTree but a DiffGraph: No root found!");
             }
 
-//            countRootTypes.merge(root.nodeType, 1, Integer::sum);
+//            countRootTypes.merge(root.getNodeType(), 1, Integer::sum);
 
 			return new DiffTree<>(root, diffTreeSource);
 		} else {

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/LineGraphImport.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/LineGraphImport.java
@@ -7,6 +7,7 @@ import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.source.DiffTreeSource;
 import org.variantsync.diffdetective.variation.diff.source.LineGraphFileSource;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.NodeType;
 import org.variantsync.functjonal.Pair;
 
@@ -33,7 +34,7 @@ public class LineGraphImport {
      * @return All {@link DiffTree DiffTrees} contained in the linegraph file.
 	 * @throws IOException when {@link LineGraphImport#fromLineGraph(BufferedReader, Path, LineGraphImportOptions)} throws.
      */
-    public static List<DiffTree> fromFile(final Path path, final LineGraphImportOptions options) throws IOException {
+    public static List<DiffTree<DiffLinesLabel>> fromFile(final Path path, final LineGraphImportOptions<DiffLinesLabel> options) throws IOException {
         Assert.assertTrue(Files.isRegularFile(path));
         Assert.assertTrue(FileUtils.isLineGraph(path));
         try (BufferedReader input = Files.newBufferedReader(path)) {
@@ -49,16 +50,16 @@ public class LineGraphImport {
 	 * @param options Options for the import, such as hints for the used formats for node and edge labels.
 	 * @return All {@link DiffTree DiffTrees} contained in the linegraph text.
 	 */
-	public static List<DiffTree> fromLineGraph(final BufferedReader lineGraph, final Path originalFile, final LineGraphImportOptions options) throws IOException {
+	public static List<DiffTree<DiffLinesLabel>> fromLineGraph(final BufferedReader lineGraph, final Path originalFile, final LineGraphImportOptions<DiffLinesLabel> options) throws IOException {
 		// All DiffTrees read from the line graph
-		List<DiffTree> diffTreeList = new ArrayList<>();
-		
+		List<DiffTree<DiffLinesLabel>> diffTreeList = new ArrayList<>();
+
 		// All DiffNodes of one DiffTree for determining the root node
-		List<DiffNode> diffNodeList = new ArrayList<>();
-		
+		List<DiffNode<DiffLinesLabel>> diffNodeList = new ArrayList<>();
+
 		// A hash map of DiffNodes
 		// <id of DiffNode, DiffNode>
-		HashMap<Integer, DiffNode> diffNodes = new HashMap<>();
+		HashMap<Integer, DiffNode<DiffLinesLabel>> diffNodes = new HashMap<>();
 
 		// The previously read DiffTree
 		String previousDiffTreeLine = "";
@@ -70,7 +71,7 @@ public class LineGraphImport {
 				// the line represents a DiffTree
 				
 				if (!diffNodeList.isEmpty()) {
-					DiffTree curDiffTree = parseDiffTree(previousDiffTreeLine, originalFile, diffNodeList, options); // parse to DiffTree
+					DiffTree<DiffLinesLabel> curDiffTree = parseDiffTree(previousDiffTreeLine, originalFile, diffNodeList, options); // parse to DiffTree
 					diffTreeList.add(curDiffTree); // add newly computed DiffTree to the list of all DiffTrees
 					
 					// Remove all DiffNodes from list
@@ -82,7 +83,7 @@ public class LineGraphImport {
 				// the line represents a DiffNode
 				
 				// parse node from input line
-				final Pair<Integer, DiffNode> idAndNode = options.nodeFormat().fromLineGraphLine(ln);
+				final Pair<Integer, DiffNode<DiffLinesLabel>> idAndNode = options.nodeFormat().fromLineGraphLine(ln);
 			
 				// add DiffNode to lists of current DiffTree
 				diffNodeList.add(idAndNode.second());
@@ -104,7 +105,7 @@ public class LineGraphImport {
 		}
 
 		if (!diffNodeList.isEmpty()) {
-			DiffTree curDiffTree = parseDiffTree(previousDiffTreeLine, originalFile, diffNodeList, options); // parse to DiffTree
+			DiffTree<DiffLinesLabel> curDiffTree = parseDiffTree(previousDiffTreeLine, originalFile, diffNodeList, options); // parse to DiffTree
 			diffTreeList.add(curDiffTree); // add newly computed DiffTree to the list of all DiffTrees
 		}
 		
@@ -121,7 +122,7 @@ public class LineGraphImport {
 	 * @param options {@link LineGraphImportOptions}
 	 * @return {@link DiffTree} generated from the given, already parsed parameters.
 	 */
-	private static DiffTree parseDiffTree(final String lineGraph, final Path inFile, final List<DiffNode> diffNodeList, final LineGraphImportOptions options) {
+	private static DiffTree<DiffLinesLabel> parseDiffTree(final String lineGraph, final Path inFile, final List<DiffNode<DiffLinesLabel>> diffNodeList, final LineGraphImportOptions<DiffLinesLabel> options) {
 		DiffTreeSource diffTreeSource = options.treeFormat().fromLineGraphLine(lineGraph);
 
 		if (diffTreeSource == null || DiffTreeSource.Unknown.equals(diffTreeSource)) {
@@ -136,8 +137,8 @@ public class LineGraphImport {
 			return DiffGraph.fromNodes(diffNodeList, diffTreeSource);
 		} else if (options.graphFormat() == GraphFormat.DIFFTREE) {
 			// If you should interpret the input data as DiffTrees, always expect a root to be present. Parse all nodes (v) to a list of nodes. Search for the root. Assert that there is exactly one root.
-            DiffNode root = null;
-            for (final DiffNode v : diffNodeList) {
+            DiffNode<DiffLinesLabel> root = null;
+            for (final DiffNode<DiffLinesLabel> v : diffNodeList) {
                 if (v.isRoot()) {
                     // v is root candidate
                     if (root != null) {
@@ -157,7 +158,7 @@ public class LineGraphImport {
 
 //            countRootTypes.merge(root.nodeType, 1, Integer::sum);
 
-			return new DiffTree(root, diffTreeSource);
+			return new DiffTree<>(root, diffTreeSource);
 		} else {
 			throw new RuntimeException("Unsupported GraphFormat");
 		}

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/LineGraphImportOptions.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/LineGraphImportOptions.java
@@ -1,5 +1,6 @@
 package org.variantsync.diffdetective.variation.diff.serialize;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.serialize.edgeformat.EdgeLabelFormat;
 import org.variantsync.diffdetective.variation.diff.serialize.nodeformat.DiffNodeLabelFormat;
@@ -13,8 +14,8 @@ import org.variantsync.diffdetective.variation.diff.serialize.treeformat.DiffTre
  * @param nodeFormat {@link DiffNodeLabelFormat}
  * @param edgeFormat {@link EdgeLabelFormat}
  */
-public record LineGraphImportOptions(
+public record LineGraphImportOptions<L extends Label>(
         GraphFormat graphFormat,
         DiffTreeLabelFormat treeFormat,
-        DiffNodeLabelFormat nodeFormat,
-        EdgeLabelFormat edgeFormat) { }
+        DiffNodeLabelFormat<? super L> nodeFormat,
+        EdgeLabelFormat<? super L> edgeFormat) { }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/StyledEdge.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/StyledEdge.java
@@ -1,5 +1,6 @@
 package org.variantsync.diffdetective.variation.diff.serialize;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 
 /**
@@ -9,7 +10,7 @@ import org.variantsync.diffdetective.variation.diff.DiffNode;
  * {@code to}. Information related to the type of the relation between {@code from} and {@code to}
  * should be encoded into {@code style}.
  */
-public record StyledEdge(DiffNode from, DiffNode to, Style style) {
+public record StyledEdge<L extends Label>(DiffNode<L> from, DiffNode<L> to, Style style) {
     public record Style(String lineGraphType, String tikzStyle) {
     }
 

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/TikzExporter.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/TikzExporter.java
@@ -3,6 +3,7 @@ package org.variantsync.diffdetective.variation.diff.serialize;
 import org.variantsync.diffdetective.show.engine.geom.Vec2;
 import org.variantsync.diffdetective.util.IO;
 import org.variantsync.diffdetective.util.LaTeX;
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 
@@ -25,10 +26,10 @@ import java.util.stream.Stream;
  * example for all required styles can be found in the file {@code tikz_header.tex} in the resource
  * directory. This particular style is used by {@link exportFullLatexExample}.
  */
-public final class TikzExporter implements Exporter {
-    private Format format;
+public final class TikzExporter<L extends Label> implements Exporter<L> {
+    private Format<? super L> format;
 
-    public TikzExporter(Format format) {
+    public TikzExporter(Format<? super L> format) {
         this.format = format;
     }
 
@@ -43,7 +44,7 @@ public final class TikzExporter implements Exporter {
      * @param destination where the result should be written
      */
     @Override
-    public void exportDiffTree(DiffTree diffTree, OutputStream destination) throws IOException {
+    public <La extends L> void exportDiffTree(DiffTree<La> diffTree, OutputStream destination) throws IOException {
         exportDiffTree(diffTree, GraphvizExporter.LayoutAlgorithm.DOT, destination);
     }
 
@@ -53,16 +54,16 @@ public final class TikzExporter implements Exporter {
      * Same as {@link exportDiffTree(DiffTree, OutputStream)}, but allows the selection of
      * a different Graphviz layout algorithm.
      */
-    public void exportDiffTree(
-            DiffTree diffTree,
+    public <La extends L> void exportDiffTree(
+            DiffTree<La> diffTree,
             GraphvizExporter.LayoutAlgorithm algorithm,
             OutputStream destination
             ) throws IOException {
-        final Map<Integer, DiffNode> ids = new HashMap<>();
+        final Map<Integer, DiffNode<La>> ids = new HashMap<>();
         diffTree.forAll(node -> ids.put(node.getID(), node));
 
         // Convert the layout information received by Graphviz to coordinates used by TikZ.
-        final Map<DiffNode, Vec2> positions = new HashMap<>();
+        final Map<DiffNode<La>, Vec2> positions = new HashMap<>();
         GraphvizExporter.layoutNodesIn(diffTree, format, algorithm, (id, x, y) ->
                 positions.put(ids.get(id), new Vec2(x, y))
         );
@@ -74,9 +75,9 @@ public final class TikzExporter implements Exporter {
                 true);
     }
 
-    public void exportDiffTree(
-            DiffTree diffTree,
-            Function<DiffNode, Vec2> nodeLayout,
+    public <La extends L> void exportDiffTree(
+            DiffTree<La> diffTree,
+            Function<DiffNode<La>, Vec2> nodeLayout,
             OutputStream destination,
             boolean escape
     ) {
@@ -145,7 +146,7 @@ public final class TikzExporter implements Exporter {
      * @param diffTree to be exported
      * @param destination path of the generated file
      */
-    public void exportFullLatexExample(DiffTree diffTree, Path destination) throws IOException {
+    public <La extends L> void exportFullLatexExample(DiffTree<La> diffTree, Path destination) throws IOException {
         try (var file = IO.newBufferedOutputStream(destination)) {
             try (var header = new BufferedInputStream(getClass().getResourceAsStream("/tikz_header.tex"))) {
                 header.transferTo(file);

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/edgeformat/ChildOrderEdgeFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/edgeformat/ChildOrderEdgeFormat.java
@@ -3,6 +3,7 @@ package org.variantsync.diffdetective.variation.diff.serialize.edgeformat;
 import static org.variantsync.diffdetective.variation.diff.Time.AFTER;
 import static org.variantsync.diffdetective.variation.diff.Time.BEFORE;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffTree; // For JavaDoc
 import org.variantsync.diffdetective.variation.diff.Time;
 import org.variantsync.diffdetective.variation.diff.serialize.StyledEdge;
@@ -18,9 +19,9 @@ import org.variantsync.diffdetective.variation.diff.serialize.StyledEdge;
  *
  * @author Benjamin Moosherr
  */
-public class ChildOrderEdgeFormat extends EdgeLabelFormat {
+public class ChildOrderEdgeFormat<L extends Label> extends EdgeLabelFormat<L> {
     @Override
-    public String labelOf(StyledEdge edge) {
+    public <La extends L> String labelOf(StyledEdge<La> edge) {
         int[] index = new int[2];
         Time.forAll(time -> {
             int i = edge.from().indexOfChild(edge.to(), time);

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/edgeformat/DefaultEdgeLabelFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/edgeformat/DefaultEdgeLabelFormat.java
@@ -1,5 +1,6 @@
 package org.variantsync.diffdetective.variation.diff.serialize.edgeformat;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.serialize.StyledEdge;
 
 /**
@@ -7,7 +8,7 @@ import org.variantsync.diffdetective.variation.diff.serialize.StyledEdge;
  * This format does not add any extra information to edge's labels.
  * @author Paul Bittner
  */
-public class DefaultEdgeLabelFormat extends EdgeLabelFormat {
+public class DefaultEdgeLabelFormat<L extends Label> extends EdgeLabelFormat<L> {
     /**
      * Creates a new default edge label format.
      */
@@ -24,7 +25,7 @@ public class DefaultEdgeLabelFormat extends EdgeLabelFormat {
     }
 
     @Override
-    public String labelOf(StyledEdge edge) {
+    public <La extends L> String labelOf(StyledEdge<La> edge) {
         return "";
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/edgeformat/EdgeLabelFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/edgeformat/EdgeLabelFormat.java
@@ -1,5 +1,6 @@
 package org.variantsync.diffdetective.variation.diff.serialize.edgeformat;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.Time;
 import org.variantsync.diffdetective.variation.diff.serialize.LineGraphConstants;
@@ -18,7 +19,7 @@ import static org.variantsync.diffdetective.variation.diff.Time.BEFORE;
  *
  * @author Kevin Jedelhauser, Paul Maximilian Bittner
  */
-public abstract class EdgeLabelFormat implements LinegraphFormat {
+public abstract class EdgeLabelFormat<L extends Label> implements LinegraphFormat {
     /**
      * Creates a new format with the {@link Direction#Default default direction}.
      */
@@ -95,7 +96,7 @@ public abstract class EdgeLabelFormat implements LinegraphFormat {
      * @param edgeLabel The label that describes the time, the edge exists at, by being prefixed with one of the
      *                  LineGraphConstants described above.
      */
-    protected void connectAccordingToLabel(final DiffNode child, final DiffNode parent, final String edgeLabel) {
+    protected <La extends L> void connectAccordingToLabel(final DiffNode<La> child, final DiffNode<La> parent, final String edgeLabel) {
         if (edgeLabel.startsWith(LineGraphConstants.BEFORE_AND_AFTER_PARENT)) {
             // Nothing has been changed. The child-parent relationship remains the same
             Time.forAll(time -> parent.addChild(child, time));
@@ -119,7 +120,7 @@ public abstract class EdgeLabelFormat implements LinegraphFormat {
      * @param nodes All nodes that have been parsed so far, indexed by their id.
      * @throws IllegalArgumentException when a node referenced in the lineGraphLine does not exist in the given map.
      */
-    public void connect(final String lineGraphLine, final Map<Integer, DiffNode> nodes) throws IllegalArgumentException {
+    public <La extends L> void connect(final String lineGraphLine, final Map<Integer, DiffNode<La>> nodes) throws IllegalArgumentException {
         if (!lineGraphLine.startsWith(LineGraphConstants.LG_EDGE)) throw new IllegalArgumentException("Failed to parse DiffNode: Expected \"v ...\" but got \"" + lineGraphLine + "\"!"); // check if encoded DiffNode
 
         String[] edge = lineGraphLine.split(" ");
@@ -130,8 +131,8 @@ public abstract class EdgeLabelFormat implements LinegraphFormat {
         final Pair<String, String> fromAndToIds = edgeDirection.sort(edge[1], edge[2]);
 
         // Both child and parent DiffNode should exist since all DiffNodes have been read in before. Otherwise, the line graph input is faulty
-        DiffNode childNode = nodes.get(Integer.parseInt(fromAndToIds.first()));
-        DiffNode parentNode = nodes.get(Integer.parseInt(fromAndToIds.second()));
+        DiffNode<La> childNode = nodes.get(Integer.parseInt(fromAndToIds.first()));
+        DiffNode<La> parentNode = nodes.get(Integer.parseInt(fromAndToIds.second()));
 
         if (childNode == null) {
             throw new IllegalArgumentException(fromAndToIds.first() + " does not exits. Faulty line graph.");
@@ -150,7 +151,7 @@ public abstract class EdgeLabelFormat implements LinegraphFormat {
      * @param edge The {@link StyledEdge} to be labeled
      * @return a label for {@code edge}
      */
-    public abstract String labelOf(StyledEdge edge);
+    public abstract <La extends L> String labelOf(StyledEdge<La> edge);
 
     /**
      * Converts a {@link StyledEdge} into a multi line label suitable for exporting.
@@ -160,7 +161,7 @@ public abstract class EdgeLabelFormat implements LinegraphFormat {
      * @param edge The {@link StyledEdge} to be labeled
      * @return a list of lines of the label for {@code edge}
      */
-    public List<String> multilineLabelOf(StyledEdge edge) {
+    public <La extends L> List<String> multilineLabelOf(StyledEdge<La> edge) {
         return List.of(labelOf(edge));
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/DebugDiffNodeFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/DebugDiffNodeFormat.java
@@ -11,7 +11,7 @@ import org.variantsync.diffdetective.variation.diff.DiffNode;
 public class DebugDiffNodeFormat<L extends Label> implements DiffNodeLabelFormat<L> {
 	@Override
 	public String toLabel(final DiffNode<? extends L> node) {
-		return node.diffType + "_" + node.nodeType + "_\"" +
+		return node.diffType + "_" + node.getNodeType() + "_\"" +
 				DiffNodeLabelPrettyfier.prettyPrintIfAnnotationOr(
 						node,
 						FileUtils.replaceLineEndings(node.getLabel().toString().trim().replaceAll("\t", "  "), "<br>"))

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/DebugDiffNodeFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/DebugDiffNodeFormat.java
@@ -1,15 +1,16 @@
 package org.variantsync.diffdetective.variation.diff.serialize.nodeformat;
 
 import org.variantsync.diffdetective.util.FileUtils;
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 
 /**
  * Print NodeType, DiffType and Mappings for Annotations and Text for Artifacts.
  * @author Paul Bittner, Kevin Jedelhauser
  */
-public class DebugDiffNodeFormat implements DiffNodeLabelFormat {
+public class DebugDiffNodeFormat<L extends Label> implements DiffNodeLabelFormat<L> {
 	@Override
-	public String toLabel(final DiffNode node) {
+	public String toLabel(final DiffNode<? extends L> node) {
 		return node.diffType + "_" + node.nodeType + "_\"" +
 				DiffNodeLabelPrettyfier.prettyPrintIfAnnotationOr(
 						node,

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/DiffNodeLabelFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/DiffNodeLabelFormat.java
@@ -2,6 +2,8 @@ package org.variantsync.diffdetective.variation.diff.serialize.nodeformat;
 
 import java.util.List;
 
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.serialize.LineGraphConstants;
 import org.variantsync.diffdetective.variation.diff.serialize.LinegraphFormat;
@@ -13,7 +15,7 @@ import org.variantsync.functjonal.Pair;
  * @author Paul Bittner, Kevin Jedelhauser
  */
 @FunctionalInterface
-public interface DiffNodeLabelFormat extends LinegraphFormat {
+public interface DiffNodeLabelFormat<L extends Label> extends LinegraphFormat {
 	/**
 	 * Converts a label of line graph into a {@link DiffNode}.
 	 * 
@@ -21,7 +23,7 @@ public interface DiffNodeLabelFormat extends LinegraphFormat {
 	 * @param nodeId The id of the {@link DiffNode}
 	 * @return The corresponding {@link DiffNode}
 	 */
-	default DiffNode fromLabelAndId(final String lineGraphNodeLabel, final int nodeId) {
+	default DiffNode<DiffLinesLabel> fromLabelAndId(final String lineGraphNodeLabel, final int nodeId) {
 	    return DiffNode.fromID(nodeId, lineGraphNodeLabel);
 	}
 
@@ -32,7 +34,7 @@ public interface DiffNodeLabelFormat extends LinegraphFormat {
      * @param node The {@link DiffNode} to be labeled
      * @return a label for {@code node}
      */
-    String toLabel(DiffNode node);
+    String toLabel(DiffNode<? extends L> node);
 
     /**
      * Converts a {@link DiffNode} into a multi line label suitable for exporting.
@@ -42,7 +44,7 @@ public interface DiffNodeLabelFormat extends LinegraphFormat {
      * @param node The {@link DiffNode} to be labeled
      * @return a list of lines of the label for {@code node}
      */
-    default List<String> toMultilineLabel(DiffNode node) {
+    default List<String> toMultilineLabel(DiffNode<? extends L> node) {
         return List.of(toLabel(node));
     }
 
@@ -53,7 +55,7 @@ public interface DiffNodeLabelFormat extends LinegraphFormat {
      * @return A pair with the first element being the id of the node specified in the given lineGrapLine.
      *         The second entry is the parsed {@link DiffNode} described by the label of this line.
      */
-    default Pair<Integer, DiffNode> fromLineGraphLine(final String lineGraphLine) {
+    default Pair<Integer, DiffNode<DiffLinesLabel>> fromLineGraphLine(final String lineGraphLine) {
         if (!lineGraphLine.startsWith(LineGraphConstants.LG_NODE)) throw new RuntimeException("Failed to parse DiffNode: Expected \"v ...\" but got \"" + lineGraphLine + "\"!"); // check if encoded DiffNode
 
         final int idBegin = LineGraphConstants.LG_NODE.length() + 1;

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/DiffNodeLabelPrettyfier.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/DiffNodeLabelPrettyfier.java
@@ -15,7 +15,7 @@ public abstract class DiffNodeLabelPrettyfier {
      * @param node The {@link DiffNode} to print.
      * @return NodeType and {@link DiffNode#getFormula} of the node in a single string, seperated by a space character.
      */
-    private static String prettyPrintTypeAndMapping(final DiffNode node) {
+    private static String prettyPrintTypeAndMapping(final DiffNode<?> node) {
         String result = node.nodeType.name;
         final Node fm = node.getFormula();
         if (fm != null) {
@@ -31,7 +31,7 @@ public abstract class DiffNodeLabelPrettyfier {
      * @param elseValue The value to return in case the given node is not an annotation.
      * @return The generated label.
      */
-    public static String prettyPrintIfAnnotationOr(final DiffNode node, final String elseValue) {
+    public static String prettyPrintIfAnnotationOr(final DiffNode<?> node, final String elseValue) {
         String result = "";
         if (node.isAnnotation()) {
             result += prettyPrintTypeAndMapping(node);

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/DiffNodeLabelPrettyfier.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/DiffNodeLabelPrettyfier.java
@@ -10,13 +10,13 @@ import org.variantsync.diffdetective.variation.NodeType;
 public abstract class DiffNodeLabelPrettyfier {
     /**
      * Auxiliary method for {@link DiffNodeLabelPrettyfier#prettyPrintIfAnnotationOr(DiffNode, String)}.
-     * Returns a string starting with the nodes {@link DiffNode#nodeType}, and its {@link DiffNode#getFormula()}
+     * Returns a string starting with the nodes {@link DiffNode#getNodeType()}, and its {@link DiffNode#getFormula()}
      * if it has a formula.
      * @param node The {@link DiffNode} to print.
      * @return NodeType and {@link DiffNode#getFormula} of the node in a single string, seperated by a space character.
      */
     private static String prettyPrintTypeAndMapping(final DiffNode<?> node) {
-        String result = node.nodeType.name;
+        String result = node.getNodeType().name;
         final Node fm = node.getFormula();
         if (fm != null) {
             result += " " + fm;

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/EditClassesDiffNodeFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/EditClassesDiffNodeFormat.java
@@ -1,11 +1,12 @@
 package org.variantsync.diffdetective.variation.diff.serialize.nodeformat;
 
 import org.variantsync.diffdetective.editclass.proposed.ProposedEditClasses;
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 
-public class EditClassesDiffNodeFormat implements DiffNodeLabelFormat {
+public class EditClassesDiffNodeFormat<L extends Label> implements DiffNodeLabelFormat<L> {
     @Override
-    public String toLabel(DiffNode node) {
+    public String toLabel(DiffNode<? extends L> node) {
         return ShowNodeFormat.toLabel(
                 node,
                 n -> ProposedEditClasses.Instance.match(node).getName()

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/FormulasAndLineNumbersNodeFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/FormulasAndLineNumbersNodeFormat.java
@@ -1,6 +1,7 @@
 package org.variantsync.diffdetective.variation.diff.serialize.nodeformat;
 
 import org.variantsync.diffdetective.diff.text.DiffLineNumber; // For Javadoc
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 
 /**
@@ -11,9 +12,9 @@ import org.variantsync.diffdetective.variation.diff.DiffNode;
  * @see DiffLineNumber#inDiff
  * @author Paul Bittner, Kevin Jedelhauser
  */
-public class FormulasAndLineNumbersNodeFormat implements DiffNodeLabelFormat {
+public class FormulasAndLineNumbersNodeFormat<L extends Label> implements DiffNodeLabelFormat<L> {
     @Override
-    public String toLabel(DiffNode node) {
+    public String toLabel(DiffNode<? extends L> node) {
         final String lineNumbers = node.getFromLine().inDiff() + "-" + node.getToLine().inDiff() + ": " + node.nodeType;
         if (node.isAnnotation()) {
             return lineNumbers + " " + node.getFormula();

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/FormulasAndLineNumbersNodeFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/FormulasAndLineNumbersNodeFormat.java
@@ -15,7 +15,7 @@ import org.variantsync.diffdetective.variation.diff.DiffNode;
 public class FormulasAndLineNumbersNodeFormat<L extends Label> implements DiffNodeLabelFormat<L> {
     @Override
     public String toLabel(DiffNode<? extends L> node) {
-        final String lineNumbers = node.getFromLine().inDiff() + "-" + node.getToLine().inDiff() + ": " + node.nodeType;
+        final String lineNumbers = node.getFromLine().inDiff() + "-" + node.getToLine().inDiff() + ": " + node.getNodeType();
         if (node.isAnnotation()) {
             return lineNumbers + " " + node.getFormula();
         }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/FullNodeFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/FullNodeFormat.java
@@ -28,7 +28,7 @@ public class FullNodeFormat implements DiffNodeLabelFormat<DiffLinesLabel> {
         List<String> lines = new ArrayList<>();
 
         lines.add(node.diffType.toString());
-        lines.add(node.nodeType.toString());
+        lines.add(node.getNodeType().toString());
         lines.add(node.getFromLine().toString());
         lines.add(node.getToLine().toString());
         lines.add(node.getFormula() == null ? "" : node.getFormula().toString());

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/FullNodeFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/FullNodeFormat.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 
 /**
@@ -21,9 +22,9 @@ import org.variantsync.diffdetective.variation.diff.DiffNode;
  *
  * @author Benjamin Moosherr
  */
-public class FullNodeFormat implements DiffNodeLabelFormat {
+public class FullNodeFormat implements DiffNodeLabelFormat<DiffLinesLabel> {
     @Override
-    public List<String> toMultilineLabel(final DiffNode node) {
+    public List<String> toMultilineLabel(final DiffNode<? extends DiffLinesLabel> node) {
         List<String> lines = new ArrayList<>();
 
         lines.add(node.diffType.toString());
@@ -31,13 +32,13 @@ public class FullNodeFormat implements DiffNodeLabelFormat {
         lines.add(node.getFromLine().toString());
         lines.add(node.getToLine().toString());
         lines.add(node.getFormula() == null ? "" : node.getFormula().toString());
-        lines.addAll(node.getLabelLines());
+        lines.addAll(node.getLabel().getLines());
 
         return lines;
     }
 
     @Override
-    public String toLabel(final DiffNode node) {
+    public String toLabel(final DiffNode<? extends DiffLinesLabel> node) {
         return toMultilineLabel(node)
             .stream()
             .collect(Collectors.joining(";"));

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/LabelOnlyDiffNodeFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/LabelOnlyDiffNodeFormat.java
@@ -1,14 +1,15 @@
 package org.variantsync.diffdetective.variation.diff.serialize.nodeformat;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 
 /**
  * Uses {@link DiffNode#getLabel()} as the linegraph node label.
  * @author Paul Bittner, Kevin Jedelhauser
  */
-public class LabelOnlyDiffNodeFormat implements DiffNodeLabelFormat {
+public class LabelOnlyDiffNodeFormat<L extends Label> implements DiffNodeLabelFormat<L> {
 	@Override
-	public String toLabel(final DiffNode node) {
+	public String toLabel(final DiffNode<? extends L> node) {
 		return node.getLabel().toString();
 	}
 }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/LineNumberFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/LineNumberFormat.java
@@ -1,13 +1,14 @@
 package org.variantsync.diffdetective.variation.diff.serialize.nodeformat;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 
 /**
  * Labels nodes using their line number in the source diff.
  */
-public class LineNumberFormat implements DiffNodeLabelFormat {
+public class LineNumberFormat<L extends Label> implements DiffNodeLabelFormat<L> {
 	@Override
-	public String toLabel(final DiffNode node) {
+	public String toLabel(final DiffNode<? extends L> node) {
 		return String.valueOf(node.getFromLine().inDiff());
 	}
 }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/MappingsDiffNodeFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/MappingsDiffNodeFormat.java
@@ -13,6 +13,6 @@ import org.variantsync.diffdetective.variation.diff.DiffNode;
 public class MappingsDiffNodeFormat<L extends Label> implements DiffNodeLabelFormat<L> {
 	@Override
 	public String toLabel(final DiffNode<? extends L> node) {
-		return node.diffType + "_" + node.nodeType + "_\"" + DiffNodeLabelPrettyfier.prettyPrintIfAnnotationOr(node, "") + "\"";
+		return node.diffType + "_" + node.getNodeType() + "_\"" + DiffNodeLabelPrettyfier.prettyPrintIfAnnotationOr(node, "") + "\"";
 	}
 }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/MappingsDiffNodeFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/MappingsDiffNodeFormat.java
@@ -1,5 +1,6 @@
 package org.variantsync.diffdetective.variation.diff.serialize.nodeformat;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 
 /**
@@ -9,9 +10,9 @@ import org.variantsync.diffdetective.variation.diff.DiffNode;
  * @see DiffNodeLabelPrettyfier#prettyPrintIfAnnotationOr(DiffNode, String)
  * @author Paul Bittner, Kevin Jedelhauser
  */
-public class MappingsDiffNodeFormat implements DiffNodeLabelFormat {
+public class MappingsDiffNodeFormat<L extends Label> implements DiffNodeLabelFormat<L> {
 	@Override
-	public String toLabel(final DiffNode node) {
+	public String toLabel(final DiffNode<? extends L> node) {
 		return node.diffType + "_" + node.nodeType + "_\"" + DiffNodeLabelPrettyfier.prettyPrintIfAnnotationOr(node, "") + "\"";
 	}
 }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/PaperNodeFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/PaperNodeFormat.java
@@ -3,17 +3,18 @@ package org.variantsync.diffdetective.variation.diff.serialize.nodeformat;
 import org.prop4j.NodeWriter;
 import org.variantsync.diffdetective.util.LaTeX;
 import org.variantsync.diffdetective.util.StringUtils;
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.NodeType;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 
 import java.util.Arrays;
 import java.util.List;
 
-public class PaperNodeFormat implements DiffNodeLabelFormat {
+public class PaperNodeFormat<L extends Label> implements DiffNodeLabelFormat<L> {
     public static final int MAX_ARTIFACT_LABEL_LENGTH = 12;
 
     @Override
-    public String toLabel(DiffNode node) {
+    public String toLabel(DiffNode<? extends L> node) {
         if (node.isRoot()) {
             return "r";
         }
@@ -48,7 +49,7 @@ public class PaperNodeFormat implements DiffNodeLabelFormat {
     }
 
     @Override
-    public List<String> toMultilineLabel(DiffNode node) {
+    public List<String> toMultilineLabel(DiffNode<? extends L> node) {
         return Arrays.stream(toLabel(node).split(StringUtils.LINEBREAK)).toList();
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/RenameRootNodeFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/RenameRootNodeFormat.java
@@ -2,27 +2,28 @@ package org.variantsync.diffdetective.variation.diff.serialize.nodeformat;
 
 import java.util.List;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 
 /**
  * Replaces the label of the root node with {@code "root"}.
  * @author Benjamin Moosherr
  */
-public class RenameRootNodeFormat implements DiffNodeLabelFormat {
+public class RenameRootNodeFormat<L extends Label> implements DiffNodeLabelFormat<L> {
     private final String rootLabel;
-    private final DiffNodeLabelFormat inner;
+    private final DiffNodeLabelFormat<L> inner;
 
-    public RenameRootNodeFormat(DiffNodeLabelFormat inner) {
+    public RenameRootNodeFormat(DiffNodeLabelFormat<L> inner) {
         this(inner, "root");
     }
 
-    public RenameRootNodeFormat(DiffNodeLabelFormat inner, String rootLabel) {
+    public RenameRootNodeFormat(DiffNodeLabelFormat<L> inner, String rootLabel) {
         this.rootLabel = rootLabel;
         this.inner = inner;
     }
 
     @Override
-    public String toLabel(final DiffNode node) {
+    public String toLabel(final DiffNode<? extends L> node) {
         if (node.isRoot()) {
             return rootLabel;
         } else {
@@ -31,7 +32,7 @@ public class RenameRootNodeFormat implements DiffNodeLabelFormat {
     }
 
     @Override
-    public List<String> toMultilineLabel(final DiffNode node) {
+    public List<String> toMultilineLabel(final DiffNode<? extends L> node) {
         if (node.isRoot()) {
             return List.of("root");
         } else {

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/ShowNodeFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/ShowNodeFormat.java
@@ -2,13 +2,14 @@ package org.variantsync.diffdetective.variation.diff.serialize.nodeformat;
 
 import org.prop4j.NodeWriter;
 import org.variantsync.diffdetective.util.StringUtils;
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.NodeType;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 
 import java.util.function.Function;
 
-public class ShowNodeFormat implements DiffNodeLabelFormat {
-    public static String toLabel(DiffNode node, Function<DiffNode, String> artifactPrinter) {
+public class ShowNodeFormat<L extends Label> implements DiffNodeLabelFormat<L> {
+    public static <L extends Label> String toLabel(DiffNode<L> node, Function<DiffNode<L>, String> artifactPrinter) {
         if (node.isRoot()) {
             return "r";
         }
@@ -28,7 +29,7 @@ public class ShowNodeFormat implements DiffNodeLabelFormat {
     }
 
     @Override
-    public String toLabel(DiffNode node) {
+    public String toLabel(DiffNode<? extends L> node) {
         return toLabel(
                 node,
                 n -> StringUtils.clamp(10, n.getLabel().toString().trim())

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/TypeDiffNodeFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/TypeDiffNodeFormat.java
@@ -1,14 +1,15 @@
 package org.variantsync.diffdetective.variation.diff.serialize.nodeformat;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 
 /**
  * Labels are of the form <code>DiffType_NodeType</code>.
  * @author Paul Bittner, Kevin Jedelhauser
  */
-public class TypeDiffNodeFormat implements DiffNodeLabelFormat {
+public class TypeDiffNodeFormat<L extends Label> implements DiffNodeLabelFormat<L> {
 	@Override
-	public String toLabel(final DiffNode node) {
+	public String toLabel(final DiffNode<? extends L> node) {
 		return node.diffType + "_" + node.nodeType;
 	}
 }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/TypeDiffNodeFormat.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/serialize/nodeformat/TypeDiffNodeFormat.java
@@ -10,6 +10,6 @@ import org.variantsync.diffdetective.variation.diff.DiffNode;
 public class TypeDiffNodeFormat<L extends Label> implements DiffNodeLabelFormat<L> {
 	@Override
 	public String toLabel(final DiffNode<? extends L> node) {
-		return node.diffType + "_" + node.nodeType;
+		return node.diffType + "_" + node.getNodeType();
 	}
 }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/transform/CollapseNestedNonEditedAnnotations.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/transform/CollapseNestedNonEditedAnnotations.java
@@ -2,12 +2,13 @@ package org.variantsync.diffdetective.variation.diff.transform;
 
 import org.prop4j.And;
 import org.prop4j.Node;
-import org.variantsync.diffdetective.diff.text.DiffLineNumber;
 import org.variantsync.diffdetective.util.Assert;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.DiffType;
 import org.variantsync.diffdetective.variation.diff.traverse.DiffTreeTraversal;
+import org.variantsync.functjonal.Cast;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.NodeType;
 
 import java.util.ArrayList;
@@ -30,17 +31,17 @@ import static org.variantsync.diffdetective.variation.diff.Time.BEFORE;
  *
  * @author Paul Bittner
  */
-public class CollapseNestedNonEditedAnnotations implements DiffTreeTransformer {
-    private final List<Stack<DiffNode>> chainCandidates = new ArrayList<>();
-    private final List<Stack<DiffNode>> chains = new ArrayList<>();
+public class CollapseNestedNonEditedAnnotations implements DiffTreeTransformer<DiffLinesLabel> {
+    private final List<Stack<DiffNode<DiffLinesLabel>>> chainCandidates = new ArrayList<>();
+    private final List<Stack<DiffNode<DiffLinesLabel>>> chains = new ArrayList<>();
 
     @Override
-    public List<Class<? extends DiffTreeTransformer>> getDependencies() {
-        return List.of(CutNonEditedSubtrees.class);
+    public List<Class<? extends DiffTreeTransformer<DiffLinesLabel>>> getDependencies() {
+        return List.of(Cast.unchecked(CutNonEditedSubtrees.class));
     }
 
     @Override
-    public void transform(final DiffTree diffTree) {
+    public void transform(final DiffTree<DiffLinesLabel> diffTree) {
         // find all chains
         diffTree.traverse(this::findChains);
 
@@ -49,14 +50,14 @@ public class CollapseNestedNonEditedAnnotations implements DiffTreeTransformer {
         chainCandidates.clear();
 
         // All found chains should at least have size 2.
-        for (final Stack<DiffNode> chain : chains) {
+        for (final Stack<DiffNode<DiffLinesLabel>> chain : chains) {
             Assert.assertTrue(chain.size() >= 2);
         }
 
 //        System.out.println(StringUtils.prettyPrintNestedCollections(chains));
 
         // collapse all found chains
-        for (final Stack<DiffNode> chain : chains) {
+        for (final Stack<DiffNode<DiffLinesLabel>> chain : chains) {
             collapseChain(chain);
         }
 
@@ -64,22 +65,22 @@ public class CollapseNestedNonEditedAnnotations implements DiffTreeTransformer {
         chains.clear();
     }
 
-    private void finalize(Stack<DiffNode> chain) {
+    private void finalize(Stack<DiffNode<DiffLinesLabel>> chain) {
         chainCandidates.remove(chain);
         chains.add(chain);
     }
 
-    private void findChains(DiffTreeTraversal traversal, DiffNode subtree) {
+    private void findChains(DiffTreeTraversal<DiffLinesLabel> traversal, DiffNode<DiffLinesLabel> subtree) {
         if (subtree.isNon() && subtree.isAnnotation()) {
             if (isHead(subtree)) {
-                final Stack<DiffNode> s = new Stack<>();
+                final Stack<DiffNode<DiffLinesLabel>> s = new Stack<>();
                 s.push(subtree);
                 chainCandidates.add(s);
             } else if (inChainTail(subtree)) {
-                final DiffNode parent = subtree.getParent(BEFORE); // == after parent
+                final DiffNode<DiffLinesLabel> parent = subtree.getParent(BEFORE); // == after parent
 
-                Stack<DiffNode> pushedTo = null;
-                for (final Stack<DiffNode> s : chainCandidates) {
+                Stack<DiffNode<DiffLinesLabel>> pushedTo = null;
+                for (final Stack<DiffNode<DiffLinesLabel>> s : chainCandidates) {
                     if (s.peek() == parent) {
                         s.push(subtree);
                         pushedTo = s;
@@ -96,12 +97,12 @@ public class CollapseNestedNonEditedAnnotations implements DiffTreeTransformer {
         traversal.visitChildrenOf(subtree);
     }
 
-    private static void collapseChain(Stack<DiffNode> chain) {
-        final DiffNode end = chain.peek();
-        final DiffNode head = chain.firstElement();
+    private static void collapseChain(Stack<DiffNode<DiffLinesLabel>> chain) {
+        final DiffNode<DiffLinesLabel> end = chain.peek();
+        final DiffNode<DiffLinesLabel> head = chain.firstElement();
         final ArrayList<Node> featureMappings = new ArrayList<>(chain.size());
 
-        DiffNode lastPopped = null;
+        DiffNode<DiffLinesLabel> lastPopped = null;
         Assert.assertTrue(!chain.isEmpty());
         while (!chain.isEmpty()) {
             lastPopped = chain.pop();
@@ -124,16 +125,16 @@ public class CollapseNestedNonEditedAnnotations implements DiffTreeTransformer {
 
         Assert.assertTrue(head == lastPopped);
 
-        final DiffNode beforeParent = head.getParent(BEFORE);
-        final DiffNode afterParent = head.getParent(AFTER);
+        final DiffNode<DiffLinesLabel> beforeParent = head.getParent(BEFORE);
+        final DiffNode<DiffLinesLabel> afterParent = head.getParent(AFTER);
 
-        var lines = new ArrayList<DiffNode.Label.Line>();
-        lines.add(DiffNode.Label.Line.withInvalidLineNumber("$Collapsed Nested Annotations$"));
-        final DiffNode merged = new DiffNode(
+        var label = new DiffLinesLabel();
+        label.addDiffLine(DiffLinesLabel.Line.withInvalidLineNumber("$Collapsed Nested Annotations$"));
+        final var merged = new DiffNode<>(
                 DiffType.NON, NodeType.IF,
                 head.getFromLine(), head.getToLine(),
                 new And(featureMappings.toArray()),
-                new DiffNode.Label(lines));
+                label);
 
         head.drop();
         merged.stealChildrenOf(end);
@@ -143,39 +144,39 @@ public class CollapseNestedNonEditedAnnotations implements DiffTreeTransformer {
     /**
      * @return True iff at least one child of was edited.
      */
-    private static boolean anyChildEdited(DiffNode d) {
+    private static boolean anyChildEdited(DiffNode<?> d) {
         return d.getAllChildrenStream().anyMatch(c -> !c.isNon());
     }
 
     /**
      * @return True iff no child of was edited.
      */
-    private static boolean noChildEdited(DiffNode d) {
+    private static boolean noChildEdited(DiffNode<?> d) {
         return d.getAllChildrenStream().allMatch(DiffNode::isNon);
     }
 
-    private static boolean hasExactlyOneChild(DiffNode d) {
+    private static boolean hasExactlyOneChild(DiffNode<?> d) {
         return d.getAllChildrenStream().limit(2).count() == 1;
     }
 
     /**
      * @return True iff d is in the tail of a chain.
      */
-    private static boolean inChainTail(DiffNode d) {
+    private static boolean inChainTail(DiffNode<?> d) {
         return d.getParent(BEFORE) == d.getParent(AFTER) && hasExactlyOneChild(d.getParent(BEFORE));
     }
 
     /**
      * @return True iff d is the head of a chain.
      */
-    private static boolean isHead(DiffNode d) {
+    private static boolean isHead(DiffNode<?> d) {
         return (!inChainTail(d) || d.getParent(BEFORE).isRoot()) && !isEnd(d);
     }
 
     /**
      * @return True iff d is the end of a chain and any chain ending at d has to end.
      */
-    private static boolean isEnd(DiffNode d) {
+    private static boolean isEnd(DiffNode<?> d) {
         return inChainTail(d) && (anyChildEdited(d) || !hasExactlyOneChild(d));
     }
 

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/transform/CollapseNestedNonEditedAnnotations.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/transform/CollapseNestedNonEditedAnnotations.java
@@ -107,7 +107,7 @@ public class CollapseNestedNonEditedAnnotations implements DiffTreeTransformer<D
         while (!chain.isEmpty()) {
             lastPopped = chain.pop();
 
-            switch (lastPopped.nodeType) {
+            switch (lastPopped.getNodeType()) {
                 case IF ->
                     featureMappings.add(lastPopped.getFeatureMapping(AFTER));
                 case ELSE, ELIF -> {
@@ -119,7 +119,7 @@ public class CollapseNestedNonEditedAnnotations implements DiffTreeTransformer<D
                     }
                 }
                 case ARTIFACT ->
-                    throw new RuntimeException("Unexpected node type " + lastPopped.nodeType + " within annotation chain!");
+                    throw new RuntimeException("Unexpected node type " + lastPopped.getNodeType() + " within annotation chain!");
             }
         }
 

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/transform/CutNonEditedSubtrees.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/transform/CutNonEditedSubtrees.java
@@ -1,5 +1,6 @@
 package org.variantsync.diffdetective.variation.diff.transform;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.traverse.DiffTreeTraversal;
@@ -18,16 +19,16 @@ import static org.variantsync.diffdetective.variation.diff.Time.BEFORE;
  * of our edit classes in our ESEC/FSE'22 paper.
  * @author Paul Bittner
  */
-public class CutNonEditedSubtrees implements DiffTreeTransformer, DiffTreeVisitor {
+public class CutNonEditedSubtrees<L extends Label> implements DiffTreeTransformer<L>, DiffTreeVisitor<L> {
     @Override
-    public void transform(final DiffTree diffTree) {
+    public void transform(final DiffTree<L> diffTree) {
         diffTree.traverse(this);
     }
 
     @Override
-    public void visit(final DiffTreeTraversal traversal, final DiffNode subtree) {
-        final ArrayList<DiffNode> collapsableChildren = new ArrayList<>();
-        for (final DiffNode child : subtree.getAllChildren()) {
+    public void visit(final DiffTreeTraversal<L> traversal, final DiffNode<L> subtree) {
+        final ArrayList<DiffNode<L>> collapsableChildren = new ArrayList<>();
+        for (final DiffNode<L> child : subtree.getAllChildren()) {
             traversal.visit(child);
 
             /*

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/transform/DiffTreeTransformer.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/transform/DiffTreeTransformer.java
@@ -1,5 +1,6 @@
 package org.variantsync.diffdetective.variation.diff.transform;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 
 import java.util.ArrayList;
@@ -10,20 +11,20 @@ import java.util.List;
  * A DiffTreeTransformer is intended to alter a given DiffTree.
  * @author Paul Bittner
  */
-public interface DiffTreeTransformer {
+public interface DiffTreeTransformer<L extends Label> {
     /**
      * Apply a transformation to the given DiffTree inplace.
      * The given tree will be changed.
      * @param diffTree The DiffTree to transform.
      */
-    void transform(final DiffTree diffTree);
+    void transform(final DiffTree<L> diffTree);
 
     /**
      * Returns a list of dependencies to other transformers.
      * A transformer should only be run, if another transformation with the respective type was run for each type on the dependencies.
      * @return List of types of which instances should be run before applying this transformation.
      */
-    default List<Class<? extends DiffTreeTransformer>> getDependencies() {
+    default List<Class<? extends DiffTreeTransformer<L>>> getDependencies() {
         return new ArrayList<>(0);
     }
 
@@ -33,11 +34,11 @@ public interface DiffTreeTransformer {
      * @param transformers The transformers whose dependencies to check.
      * @throws RuntimeException when a dependency is not met.
      */
-    static void checkDependencies(final List<DiffTreeTransformer> transformers) {
+    static <L extends Label> void checkDependencies(final List<DiffTreeTransformer<L>> transformers) {
         for (int i = transformers.size() - 1; i >= 0; --i) {
-            final DiffTreeTransformer currentTransformer = transformers.get(i);
-            final List<Class<? extends DiffTreeTransformer>> currentDependencies = currentTransformer.getDependencies();
-            for (final Class<? extends DiffTreeTransformer> dependency : currentDependencies) {
+            final DiffTreeTransformer<L> currentTransformer = transformers.get(i);
+            final List<Class<? extends DiffTreeTransformer<L>>> currentDependencies = currentTransformer.getDependencies();
+            for (final Class<? extends DiffTreeTransformer<L>> dependency : currentDependencies) {
                 boolean dependencyMet = false;
                 for (int j = i - 1; j >= 0; --j) {
                     if (dependency.isInstance(transformers.get(j))) {
@@ -62,9 +63,9 @@ public interface DiffTreeTransformer {
      * @param transformers Transformers to apply sequentially.
      * @param tree Tree to transform inplace.
      */
-    static void apply(final List<DiffTreeTransformer> transformers, final DiffTree tree) {
+    static <L extends Label> void apply(final List<DiffTreeTransformer<L>> transformers, final DiffTree<L> tree) {
         checkDependencies(transformers);
-        for (final DiffTreeTransformer t : transformers) {
+        for (final DiffTreeTransformer<L> t : transformers) {
             t.transform(tree);
         }
     }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/transform/FeatureExpressionFilter.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/transform/FeatureExpressionFilter.java
@@ -1,5 +1,6 @@
 package org.variantsync.diffdetective.variation.diff.transform;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 
@@ -12,17 +13,17 @@ import java.util.function.Predicate;
  * For example, it might remove an IF but keep its ELSE branches which is illegal.
  */
 @Deprecated
-public record FeatureExpressionFilter(Predicate<DiffNode> isFeatureAnnotation) implements DiffTreeTransformer {
+public record FeatureExpressionFilter<L extends Label>(Predicate<DiffNode<L>> isFeatureAnnotation) implements DiffTreeTransformer<L> {
     @Override
-    public void transform(DiffTree diffTree) {
-        final List<DiffNode> illegalNodes = new ArrayList<>();
+    public void transform(DiffTree<L> diffTree) {
+        final List<DiffNode<L>> illegalNodes = new ArrayList<>();
         diffTree.forAll(node -> {
             if (node.isAnnotation() && !isFeatureAnnotation.test(node)) {
                 illegalNodes.add(node);
             }
         });
 
-        for (final DiffNode illegalAnnotation : illegalNodes) {
+        for (final DiffNode<L> illegalAnnotation : illegalNodes) {
             diffTree.removeNode(illegalAnnotation);
         }
     }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/transform/LabelWithEditClass.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/transform/LabelWithEditClass.java
@@ -3,6 +3,7 @@ package org.variantsync.diffdetective.variation.diff.transform;
 import org.variantsync.diffdetective.editclass.EditClassCatalogue;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.NodeType; // For Javadoc
 
 import java.util.List;
@@ -14,8 +15,8 @@ import java.util.List;
  * All other nodes will be labeled by the {@link NodeType#name name of their node type}.
  * @author Paul Bittner
  */
-public class LabelWithEditClass implements DiffTreeTransformer {
-    private final DiffTreeTransformer relabelNodes;
+public class LabelWithEditClass implements DiffTreeTransformer<DiffLinesLabel> {
+    private final DiffTreeTransformer<DiffLinesLabel> relabelNodes;
 
     /**
      * Creates a new transformation that will use the given catalog of edit classes
@@ -23,22 +24,22 @@ public class LabelWithEditClass implements DiffTreeTransformer {
      * @param editClasses Catalog of edit classes to match on artifact nodes.
      */
     public LabelWithEditClass(final EditClassCatalogue editClasses) {
-        relabelNodes = new RelabelNodes(d -> {
+        relabelNodes = new RelabelNodes<DiffLinesLabel>(d -> {
             if (d.isArtifact()) {
-                return editClasses.match(d).getName();
+                return DiffLinesLabel.ofCodeBlock(editClasses.match(d).getName());
             } else {
-                return d.nodeType.name;
+                return DiffLinesLabel.ofCodeBlock(d.nodeType.name);
             }
         });
     }
 
     @Override
-    public void transform(DiffTree diffTree) {
+    public void transform(DiffTree<DiffLinesLabel> diffTree) {
         relabelNodes.transform(diffTree);
     }
 
     @Override
-    public List<Class<? extends DiffTreeTransformer>> getDependencies() {
+    public List<Class<? extends DiffTreeTransformer<DiffLinesLabel>>> getDependencies() {
         return relabelNodes.getDependencies();
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/transform/LabelWithEditClass.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/transform/LabelWithEditClass.java
@@ -28,7 +28,7 @@ public class LabelWithEditClass implements DiffTreeTransformer<DiffLinesLabel> {
             if (d.isArtifact()) {
                 return DiffLinesLabel.ofCodeBlock(editClasses.match(d).getName());
             } else {
-                return DiffLinesLabel.ofCodeBlock(d.nodeType.name);
+                return DiffLinesLabel.ofCodeBlock(d.getNodeType().name);
             }
         });
     }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/transform/NaiveMovedArtifactDetection.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/transform/NaiveMovedArtifactDetection.java
@@ -1,6 +1,7 @@
 package org.variantsync.diffdetective.variation.diff.transform;
 
 import org.variantsync.diffdetective.diff.text.DiffLineNumber;
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.DiffType;
@@ -19,14 +20,14 @@ import static org.variantsync.diffdetective.variation.diff.Time.BEFORE;
  * but for each line in the nodes individually.
  * @author Paul Bittner
  */
-public class NaiveMovedArtifactDetection implements DiffTreeTransformer {
+public class NaiveMovedArtifactDetection<L extends Label> implements DiffTreeTransformer<L> {
     @Override
-    public void transform(final DiffTree diffTree) {
-        final List<Pair<DiffNode, DiffNode>> twins = findArtifactTwins(diffTree);
+    public void transform(final DiffTree<L> diffTree) {
+        final List<Pair<DiffNode<L>, DiffNode<L>>> twins = findArtifactTwins(diffTree);
 
-        for (final Pair<DiffNode, DiffNode> twin : twins) {
-            final DiffNode added;
-            final DiffNode removed;
+        for (final Pair<DiffNode<L>, DiffNode<L>> twin : twins) {
+            final DiffNode<L> added;
+            final DiffNode<L> removed;
 
             // Determine which one is the added and which is the removed node.
             if (twin.first().isAdd()) {
@@ -37,9 +38,9 @@ public class NaiveMovedArtifactDetection implements DiffTreeTransformer {
                 removed = twin.first();
             }
 
-            final DiffNode afterParent = added.getParent(AFTER);
-            final DiffNode beforeParent = removed.getParent(BEFORE);
-            final DiffNode mergedNode = merge(added, removed);
+            final DiffNode<L> afterParent = added.getParent(AFTER);
+            final DiffNode<L> beforeParent = removed.getParent(BEFORE);
+            final DiffNode<L> mergedNode = merge(added, removed);
 
             added.drop();
             removed.drop();
@@ -49,19 +50,19 @@ public class NaiveMovedArtifactDetection implements DiffTreeTransformer {
         }
     }
 
-    private static List<Pair<DiffNode, DiffNode>> findArtifactTwins(final DiffTree diffTree) {
-        final List<DiffNode> artifactNodes = diffTree.computeArtifactNodes();
-        final List<Pair<DiffNode, DiffNode>> twins = new ArrayList<>();
+    private static <L extends Label> List<Pair<DiffNode<L>, DiffNode<L>>> findArtifactTwins(final DiffTree<L> diffTree) {
+        final List<DiffNode<L>> artifactNodes = diffTree.computeArtifactNodes();
+        final List<Pair<DiffNode<L>, DiffNode<L>>> twins = new ArrayList<>();
 
         while (!artifactNodes.isEmpty()) {
             // Always inspect last element as it's the cheapest to remove.
-            final DiffNode artifact = artifactNodes.get(artifactNodes.size() - 1);
+            final DiffNode<L> artifact = artifactNodes.get(artifactNodes.size() - 1);
             artifactNodes.remove(artifact);
 
             // If the node was inserted or removed ...
             if (!artifact.isNon()) {
                 // ... check if the opposite operation was applied to the same artifact somewhere else.
-                final DiffNode twin = findTwinOf(artifact, artifactNodes);
+                final DiffNode<L> twin = findTwinOf(artifact, artifactNodes);
                 if (twin != null) {
                     twins.add(new Pair<>(artifact, twin));
                     artifactNodes.remove(twin);
@@ -72,7 +73,7 @@ public class NaiveMovedArtifactDetection implements DiffTreeTransformer {
         return twins;
     }
 
-    private static DiffNode findTwinOf(final DiffNode artifact, final List<DiffNode> artifactNodes) {
+    private static <L extends Label> DiffNode<L> findTwinOf(final DiffNode<L> artifact, final List<DiffNode<L>> artifactNodes) {
         final DiffType weAreLookingFor = artifact.diffType.inverse();
         final String text = artifact.getLabel().toString().trim();
 
@@ -82,7 +83,7 @@ public class NaiveMovedArtifactDetection implements DiffTreeTransformer {
 
         // We assert the following as we removed the artifact node in transform.
         // assert(!artifactNodes.contains(artifact));
-        for (final DiffNode other : artifactNodes) {
+        for (final DiffNode<L> other : artifactNodes) {
             if (other.diffType == weAreLookingFor && text.equals(other.getLabel().toString().trim())) {
                 return other;
             }
@@ -91,7 +92,7 @@ public class NaiveMovedArtifactDetection implements DiffTreeTransformer {
         return null;
     }
 
-    private static DiffNode merge(final DiffNode added, final DiffNode removed) {
+    private static <L extends Label> DiffNode<L> merge(final DiffNode<L> added, final DiffNode<L> removed) {
         final DiffLineNumber addFrom = added.getFromLine();
         final DiffLineNumber remFrom = removed.getFromLine();
         final DiffLineNumber addTo = added.getToLine();

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/transform/RelabelNodes.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/transform/RelabelNodes.java
@@ -1,5 +1,6 @@
 package org.variantsync.diffdetective.variation.diff.transform;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 
@@ -9,16 +10,15 @@ import java.util.function.Function;
  * Transformer that changes the label of each node using a relable function.
  * @author Paul Bittner
  */
-public class RelabelNodes implements DiffTreeTransformer {
-    private final Function<DiffNode, String> getLabel;
+public class RelabelNodes<L extends Label> implements DiffTreeTransformer<L> {
+    private final Function<DiffNode<L>, L> getLabel;
 
     /**
      * Creates a new transformation that relables each node with the given function.
      * @param newLabelOfNode This function is invoked once for each DiffNode in the transformed
      *                       DiffTree. The returned String is set as the node's new label.
-     * @see DiffNode#setLabel(String)
      */
-    public RelabelNodes(final Function<DiffNode, String> newLabelOfNode) {
+    public RelabelNodes(final Function<DiffNode<L>, L> newLabelOfNode) {
         this.getLabel = newLabelOfNode;
     }
 
@@ -26,12 +26,12 @@ public class RelabelNodes implements DiffTreeTransformer {
      * Creates a new transformation that sets the label of each node to the given string.
      * @param label The new label for each node in a DiffTree.
      */
-    public RelabelNodes(final String label) {
+    public RelabelNodes(final L label) {
         this(d -> label);
     }
 
     @Override
-    public void transform(DiffTree diffTree) {
+    public void transform(DiffTree<L> diffTree) {
         diffTree.forAll(d -> d.setLabel(getLabel.apply(d)));
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/transform/RelabelRoot.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/transform/RelabelRoot.java
@@ -1,25 +1,26 @@
 package org.variantsync.diffdetective.variation.diff.transform;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 
 /**
  * Transformer that relabels the root of a DiffTree.
  * @author Paul Bittner
  */
-public class RelabelRoot implements DiffTreeTransformer {
-    private final String newLabel;
+public class RelabelRoot<L extends Label> implements DiffTreeTransformer<L> {
+    private final L newLabel;
 
     /**
      * Creates a new transformation that will set the root's label
      * of a DiffTree to the given text.
      * @param newLabel New label for the root node.
      */
-    public RelabelRoot(final String newLabel) {
+    public RelabelRoot(final L newLabel) {
         this.newLabel = newLabel;
     }
 
     @Override
-    public void transform(DiffTree diffTree) {
+    public void transform(DiffTree<L> diffTree) {
         diffTree.getRoot().setLabel(newLabel);
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/transform/Starfold.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/transform/Starfold.java
@@ -1,6 +1,7 @@
 package org.variantsync.diffdetective.variation.diff.transform;
 
 import org.variantsync.diffdetective.diff.text.DiffLineNumber;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.DiffType;
@@ -18,7 +19,7 @@ import java.util.List;
  * This means, all inserted star-children will be merged into a single child, and for deletions respectively.
  * @author Paul Bittner, Benjamin Moosherr
  */
-public class Starfold implements DiffTreeTransformer {
+public class Starfold implements DiffTreeTransformer<DiffLinesLabel> {
     private final boolean respectNodeOrder;
 
     private Starfold(boolean respectNodeOrder) {
@@ -44,27 +45,27 @@ public class Starfold implements DiffTreeTransformer {
     }
 
     @Override
-    public void transform(DiffTree diffTree) {
+    public void transform(DiffTree<DiffLinesLabel> diffTree) {
         // All non-artifact nodes are potential roots of stars.
-        final List<DiffNode> annotations = diffTree.computeAllNodesThat(Starfold::isStarRoot);
+        final List<DiffNode<DiffLinesLabel>> annotations = diffTree.computeAllNodesThat(Starfold::isStarRoot);
 //        System.out.println("Inspecting " + annotations.size() + " star roots.");
-        for (DiffNode annotation : annotations) {
+        for (DiffNode<DiffLinesLabel> annotation : annotations) {
 //            System.out.println("Found star root " + annotation);
             foldStar(annotation);
         }
     }
 
-    private void foldStar(final DiffNode starRoot) {
+    private void foldStar(final DiffNode<DiffLinesLabel> starRoot) {
         // We fold the stars for each time respectively.
         Time.forAll(t -> foldStarAtTime(starRoot, t));
     }
 
-    private void foldStarAtTime(final DiffNode starRoot, Time time) {
+    private void foldStarAtTime(final DiffNode<DiffLinesLabel> starRoot, Time time) {
 //        System.out.println("Fold " + starRoot + " at time " + time);
         final DiffType targetDiffType = DiffType.thatExistsOnlyAt(time);
-        final List<DiffNode> starArms = new ArrayList<>();
+        final List<DiffNode<DiffLinesLabel>> starArms = new ArrayList<>();
 
-        for (DiffNode child : starRoot.getAllChildren()) {
+        for (DiffNode<DiffLinesLabel> child : starRoot.getAllChildren()) {
             if (!starRoot.isChild(child, time)) {
                 continue;
             }
@@ -84,7 +85,7 @@ public class Starfold implements DiffTreeTransformer {
         mergeArms(starRoot, time, targetDiffType, starArms);
     }
 
-    private void mergeArms(final DiffNode starRoot, Time time, final DiffType targetDiffType, final List<DiffNode> starArms) {
+    private void mergeArms(final DiffNode<DiffLinesLabel> starRoot, Time time, final DiffType targetDiffType, final List<DiffNode<DiffLinesLabel>> starArms) {
         // If there is more than one arm, merge.
         if (starArms.size() > 1) {
             final int targetIndex = starRoot.indexOfChild(starArms.get(0), time);
@@ -94,7 +95,7 @@ public class Starfold implements DiffTreeTransformer {
                             targetDiffType,
                             DiffLineNumber.Invalid(),
                             DiffLineNumber.Invalid(),
-                            DiffNode.Label.withInvalidLineNumbers(starArms.stream().flatMap(node -> node.getLabelLines().stream()).toList())
+                            new DiffLinesLabel(starArms.stream().flatMap(node -> node.getLabel().getDiffLines().stream()).toList())
                     ),
                     targetIndex,
                     time
@@ -102,11 +103,11 @@ public class Starfold implements DiffTreeTransformer {
         }
     }
 
-    private static boolean isStarRoot(final DiffNode node) {
+    private static boolean isStarRoot(final DiffNode<?> node) {
         return !node.isArtifact() && node.isNon();
     }
 
-    private static boolean isStarArm(final DiffNode node) {
+    private static boolean isStarArm(final DiffNode<?> node) {
         return node.isLeaf() && node.isArtifact();
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/traverse/DiffTreeTraversal.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/traverse/DiffTreeTraversal.java
@@ -1,5 +1,6 @@
 package org.variantsync.diffdetective.variation.diff.traverse;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 
@@ -21,11 +22,11 @@ import java.util.function.Consumer;
  *
  * @author Paul Bittner
  */
-public class DiffTreeTraversal {
-    private final Set<DiffNode> visited;
-    private final DiffTreeVisitor visitor;
+public class DiffTreeTraversal<L extends Label> {
+    private final Set<DiffNode<L>> visited;
+    private final DiffTreeVisitor<L> visitor;
 
-    private DiffTreeTraversal(final DiffTreeVisitor visitor) {
+    private DiffTreeTraversal(final DiffTreeVisitor<L> visitor) {
         this.visitor = visitor;
         this.visited = new HashSet<>();
     }
@@ -35,8 +36,8 @@ public class DiffTreeTraversal {
      * @param visitor Visitor that is invoked on each node and always decides how to proceed the traversal.
      * @return The new traversal.
      */
-    public static DiffTreeTraversal with(final DiffTreeVisitor visitor) {
-        return new DiffTreeTraversal(visitor);
+    public static <L extends Label> DiffTreeTraversal<L> with(final DiffTreeVisitor<L> visitor) {
+        return new DiffTreeTraversal<>(visitor);
     }
 
     /**
@@ -44,7 +45,7 @@ public class DiffTreeTraversal {
      * @param procedure Callback that is invoked exactly once on each DiffNode in a DiffTree.
      * @return The new traversal that will visit each node exactly once.
      */
-    public static DiffTreeTraversal forAll(final Consumer<DiffNode> procedure) {
+    public static <L extends Label> DiffTreeTraversal<L> forAll(final Consumer<DiffNode<L>> procedure) {
         return with((traversal, subtree) -> {
             procedure.accept(subtree);
             traversal.visitChildrenOf(subtree);
@@ -55,7 +56,7 @@ public class DiffTreeTraversal {
      * Start the traversal of the given tree at its root.
      * @param tree The tree to traverse.
      */
-    public void visit(final DiffTree tree) {
+    public void visit(final DiffTree<L> tree) {
         visit(tree.getRoot());
     }
 
@@ -63,7 +64,7 @@ public class DiffTreeTraversal {
      * Start the traversal of a DiffTree at the given DiffNode.
      * @param subtree The node at which to start the traversal.
      */
-    public void visit(final DiffNode subtree) {
+    public void visit(final DiffNode<L> subtree) {
         if (markAsVisited(subtree)) {
             visitor.visit(this, subtree);
         }
@@ -73,8 +74,8 @@ public class DiffTreeTraversal {
      * Continues the traversal by visiting all children of the given node sequentially.
      * @param subtree The node whose children to visit.
      */
-    public void visitChildrenOf(final DiffNode subtree) {
-        for (final DiffNode child : subtree.getAllChildren()) {
+    public void visitChildrenOf(final DiffNode<L> subtree) {
+        for (final DiffNode<L> child : subtree.getAllChildren()) {
             visit(child);
         }
     }
@@ -85,7 +86,7 @@ public class DiffTreeTraversal {
      * @return True if the node was unvisited and is now marked visited.
      *         False if the node was already marked visited.
      */
-    private boolean markAsVisited(final DiffNode node) {
+    private boolean markAsVisited(final DiffNode<L> node) {
         return visited.add(node);
     }
 }

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/traverse/DiffTreeVisitor.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/traverse/DiffTreeVisitor.java
@@ -1,5 +1,6 @@
 package org.variantsync.diffdetective.variation.diff.traverse;
 
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 
 /**
@@ -11,7 +12,7 @@ import org.variantsync.diffdetective.variation.diff.DiffNode;
  * @author Paul Bittner
  */
 @FunctionalInterface
-public interface DiffTreeVisitor {
+public interface DiffTreeVisitor<L extends Label> {
      /**
       * Invoked by a traversal when a node is visited.
       * The traversal might be continued by invoking respective methods on the given traversal object again.
@@ -20,5 +21,5 @@ public interface DiffTreeVisitor {
       * @param subtree The node that is currently visited.
       * @see DiffTreeTraversal
       */
-     void visit(final DiffTreeTraversal traversal, final DiffNode subtree);
+     void visit(final DiffTreeTraversal<L> traversal, final DiffNode<L> subtree);
 }

--- a/src/main/java/org/variantsync/diffdetective/variation/tree/VariationTree.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/tree/VariationTree.java
@@ -3,7 +3,8 @@ package org.variantsync.diffdetective.variation.tree;
 import org.variantsync.diffdetective.datasets.PatchDiffParseOptions;
 import org.variantsync.diffdetective.diff.result.DiffParseException;
 import org.variantsync.diffdetective.util.Assert;
-import org.variantsync.diffdetective.variation.NodeType; // For Javadoc
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
+import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.Projection;
@@ -31,20 +32,22 @@ import static org.variantsync.diffdetective.variation.diff.Time.BEFORE;
  *
  * @param root the root of the variation tree
  * @param source from which source code the variation tree was obtained
+ * @param <L> The type of label stored in this tree.
+ *
  * @see VariationTreeNode
  * @author Benjamin Moosherr
  */
-public record VariationTree(
-    VariationTreeNode root,
+public record VariationTree<L extends Label>(
+    VariationTreeNode<L> root,
     VariationTreeSource source
 ) {
     /** Creates a {@code VariationTree} with the given root and an unknown source. */
-    public VariationTree(VariationTreeNode root) {
+    public VariationTree(VariationTreeNode<L> root) {
         this(root, VariationTreeSource.Unknown);
     }
 
     /** Creates a {@code VariationTree} with the given root and source. */
-    public VariationTree(VariationTreeNode root, VariationTreeSource source) {
+    public VariationTree(VariationTreeNode<L> root, VariationTreeSource source) {
         this.root = root;
         this.source = source;
 
@@ -55,7 +58,7 @@ public record VariationTree(
      * Same as {@link #fromFile(BufferedReader, VariationTreeSource, DiffTreeParseOptions)}
      * but registers {@code path} as source.
      */
-    public static VariationTree fromFile(
+    public static VariationTree<DiffLinesLabel> fromFile(
         final Path path,
         final DiffTreeParseOptions parseOptions
     ) throws IOException, DiffParseException {
@@ -77,40 +80,40 @@ public record VariationTree(
      * @throws IOException if {@code input} throws {@code IOException}
      * @throws DiffParseException if some preprocessor annotations can't be parsed
      */
-    public static VariationTree fromFile(
+    public static VariationTree<DiffLinesLabel> fromFile(
             final BufferedReader input,
             final VariationTreeSource source,
             final DiffTreeParseOptions parseOptions
             ) throws IOException, DiffParseException {
-        VariationTreeNode tree = DiffTreeParser
+        VariationTreeNode<DiffLinesLabel> tree = DiffTreeParser
             .createVariationTree(input, parseOptions)
             .getRoot()
             // Arbitrarily choose the BEFORE projection as both should be equal.
             .projection(BEFORE)
             .toVariationTree();
 
-        return new VariationTree(tree, source);
+        return new VariationTree<>(tree, source);
     }
 
-    public static VariationTree fromProjection(final Projection projection, final VariationTreeSource source) {
+    public static <L extends Label> VariationTree<L> fromProjection(final Projection<L> projection, final VariationTreeSource source) {
         return fromVariationNode(projection, source);
     }
 
-    public static <T extends VariationNode<T>> VariationTree fromVariationNode(final VariationNode<T> node, final VariationTreeSource source) {
-        return new VariationTree(
+    public static <T extends VariationNode<T, L>, L extends Label> VariationTree<L> fromVariationNode(final VariationNode<T, L> node, final VariationTreeSource source) {
+        return new VariationTree<>(
                 node.toVariationTree(),
                 source
         );
     }
 
-    public DiffTree toDiffTree(final Function<VariationTreeNode, DiffNode> nodeConverter) {
-        return new DiffTree(
+    public DiffTree<L> toDiffTree(final Function<VariationTreeNode<L>, DiffNode<L>> nodeConverter) {
+        return new DiffTree<>(
                 DiffNode.unchanged(nodeConverter, root()),
                 new FromVariationTreeSource(source())
         );
     }
 
-    public DiffTree toCompletelyUnchangedDiffTree() {
+    public DiffTree<L> toCompletelyUnchangedDiffTree() {
         return toDiffTree(DiffNode::unchangedFlat);
     }
 
@@ -119,7 +122,7 @@ public record VariationTree(
      * @param action callback
      * @return this
      */
-    public VariationTree forAllPreorder(final Consumer<VariationTreeNode> action) {
+    public VariationTree<L> forAllPreorder(final Consumer<VariationTreeNode<L>> action) {
         root.forAllPreorder(action);
         return this;
     }
@@ -130,7 +133,7 @@ public record VariationTree(
      * @param condition A condition to check on each node.
      * @return True iff the given condition returns true for at least one node in this tree.
      */
-    public boolean anyMatch(final Predicate<VariationTreeNode> condition) {
+    public boolean anyMatch(final Predicate<VariationTreeNode<L>> condition) {
         return root().anyMatch(condition);
     }
 
@@ -140,7 +143,7 @@ public record VariationTree(
      * equality (i.e., nodes are compared using ==).
      * @param node The node to check for containment.
      */
-    public boolean contains(VariationTreeNode node) {
+    public boolean contains(VariationTreeNode<L> node) {
         return anyMatch(n -> n == node);
     }
 
@@ -153,7 +156,7 @@ public record VariationTree(
         return size.get();
     }
 
-    public VariationTree deepCopy() {
+    public VariationTree<L> deepCopy() {
         return deepCopy(new HashMap<>());
     }
 
@@ -167,8 +170,8 @@ public record VariationTree(
      * @param oldToNew A map that memorizes the translation of individual nodes.
      * @return A deep copy of this tree.
      */
-    public VariationTree deepCopy(final Map<VariationTreeNode, VariationTreeNode> oldToNew) {
-        return new VariationTree(root.deepCopy(oldToNew), this.source);
+    public VariationTree<L> deepCopy(final Map<VariationTreeNode<L>, VariationTreeNode<L>> oldToNew) {
+        return new VariationTree<>(root.deepCopy(oldToNew), this.source);
     }
 
     @Override

--- a/src/main/java/org/variantsync/diffdetective/variation/tree/VariationTreeNode.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/tree/VariationTreeNode.java
@@ -7,6 +7,7 @@ import org.variantsync.diffdetective.util.LineRange;
 import org.variantsync.diffdetective.util.fide.FixTrueFalse;
 import org.variantsync.diffdetective.variation.Label;
 import org.variantsync.diffdetective.variation.NodeType;
+import org.variantsync.diffdetective.variation.VariationLabel;
 import org.variantsync.diffdetective.variation.diff.DiffNode; // For Javdoc
 import org.variantsync.diffdetective.variation.diff.DiffTree; // For Javdoc
 import org.variantsync.diffdetective.variation.diff.DiffType;
@@ -50,20 +51,15 @@ import java.util.*;
  */
 public class VariationTreeNode<L extends Label> extends VariationNode<VariationTreeNode<L>, L> {
     /**
-     * The node type of this node, which determines the type of the represented
-     * element in the diff (e.g., mapping or artifact).
+     * The label together with the node type of this node, which determines the type of the
+     * represented element in the diff (e.g., mapping or artifact).
      */
-    private final NodeType nodeType;
+    private VariationLabel<L> label;
 
     /**
      * The range of line numbers of this node's corresponding source code.
      */
     private LineRange lineRange;
-
-    /**
-     * A list of lines representing the label of this node.
-     */
-    private L label;
 
     /**
      * The direct feature mapping of this node.
@@ -110,9 +106,8 @@ public class VariationTreeNode<L extends Label> extends VariationNode<VariationT
     ) {
         super();
 
-        this.nodeType = nodeType;
+        this.label = new VariationLabel<>(nodeType, label);
         this.lineRange = lineRange;
-        this.label = label;
         this.featureMapping = featureMapping;
 
         this.childOrder = new ArrayList<>();
@@ -156,12 +151,12 @@ public class VariationTreeNode<L extends Label> extends VariationNode<VariationT
 
     @Override
     public NodeType getNodeType() {
-        return nodeType;
+        return label.getNodeType();
     }
 
     @Override
     public L getLabel() {
-        return label;
+        return label.getInnerLabel();
     }
 
     /**
@@ -170,7 +165,7 @@ public class VariationTreeNode<L extends Label> extends VariationNode<VariationT
      * @see getLabel
      */
     public void setLabel(L newLabel) {
-        label = newLabel;
+        label.setInnerLabel(newLabel);
     }
 
     @Override
@@ -261,7 +256,7 @@ public class VariationTreeNode<L extends Label> extends VariationNode<VariationT
         id |= DiffType.NON.ordinal();
 
         id <<= NodeType.getRequiredBitCount();
-        id |= nodeType.ordinal();
+        id |= getNodeType().ordinal();
         return id;
     }
 
@@ -319,11 +314,11 @@ public class VariationTreeNode<L extends Label> extends VariationNode<VariationT
     public String toString() {
         String s;
         if (isArtifact()) {
-            s = String.format("%s in the lines %s", nodeType, lineRange);
+            s = String.format("%s in the lines %s", getNodeType(), lineRange);
         } else if (isRoot()) {
             s = "ROOT";
         } else {
-            s = String.format("%s in the lines %s with \"%s\"", nodeType,
+            s = String.format("%s in the lines %s with \"%s\"", getNodeType(),
                     lineRange, featureMapping);
         }
         return s;

--- a/src/main/java/org/variantsync/diffdetective/variation/tree/VariationTreeNode.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/tree/VariationTreeNode.java
@@ -2,17 +2,16 @@ package org.variantsync.diffdetective.variation.tree;
 
 import org.prop4j.Node;
 import org.variantsync.diffdetective.diff.text.DiffLineNumber;
-import org.variantsync.diffdetective.util.LineRange;
-import org.variantsync.diffdetective.util.StringUtils;
 import org.variantsync.diffdetective.util.Assert;
+import org.variantsync.diffdetective.util.LineRange;
 import org.variantsync.diffdetective.util.fide.FixTrueFalse;
+import org.variantsync.diffdetective.variation.Label;
+import org.variantsync.diffdetective.variation.NodeType;
 import org.variantsync.diffdetective.variation.diff.DiffNode; // For Javdoc
 import org.variantsync.diffdetective.variation.diff.DiffTree; // For Javdoc
 import org.variantsync.diffdetective.variation.diff.DiffType;
-import org.variantsync.diffdetective.variation.NodeType;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * A single node in a variation tree.
@@ -49,16 +48,7 @@ import java.util.stream.Collectors;
  * @see DiffNode
  * @author Benjamin Moosherr
  */
-public class VariationTreeNode extends VariationNode<VariationTreeNode> {
-    private record Lines(List<String> lines) implements Label {
-        @Override
-        public String toString() {
-            return lines
-                .stream()
-                .collect(Collectors.joining(StringUtils.LINEBREAK));
-        }
-    }
-
+public class VariationTreeNode<L extends Label> extends VariationNode<VariationTreeNode<L>, L> {
     /**
      * The node type of this node, which determines the type of the represented
      * element in the diff (e.g., mapping or artifact).
@@ -73,7 +63,7 @@ public class VariationTreeNode extends VariationNode<VariationTreeNode> {
     /**
      * A list of lines representing the label of this node.
      */
-    private Label label;
+    private L label;
 
     /**
      * The direct feature mapping of this node.
@@ -87,14 +77,14 @@ public class VariationTreeNode extends VariationNode<VariationTreeNode> {
      *
      * <p>Invariant: Iff {@code parent != null} then {@code parent.childOrder.contains(this)}.
      */
-    private VariationTreeNode parent;
+    private VariationTreeNode<L> parent;
 
     /**
      * The list for maintaining the order of all children of this node.
      *
      * @see parent
      */
-    private final List<VariationTreeNode> childOrder;
+    private final List<VariationTreeNode<L>> childOrder;
 
     /**
      * Creates a new node of a variation tree.
@@ -116,7 +106,7 @@ public class VariationTreeNode extends VariationNode<VariationTreeNode> {
         NodeType nodeType,
         Node featureMapping,
         LineRange lineRange,
-        Label label
+        L label
     ) {
         super();
 
@@ -126,24 +116,6 @@ public class VariationTreeNode extends VariationNode<VariationTreeNode> {
         this.featureMapping = featureMapping;
 
         this.childOrder = new ArrayList<>();
-    }
-
-    /**
-     * The same as {@link VariationTreeNode(NodeType, Node, LineRange, Label)} but with a minimal
-     * default implementation of {@link Label}.
-     */
-    public VariationTreeNode(
-        NodeType nodeType,
-        Node featureMapping,
-        LineRange lineRange,
-        List<String> label
-    ) {
-        this(
-            nodeType,
-            featureMapping,
-            lineRange,
-            new Lines(label)
-        );
     }
 
     /**
@@ -157,12 +129,12 @@ public class VariationTreeNode extends VariationNode<VariationTreeNode> {
      *
      * @see addChild
      */
-    public static VariationTreeNode createRoot() {
-        return new VariationTreeNode(
+    public static <L extends Label> VariationTreeNode<L> createRoot(L label) {
+        return new VariationTreeNode<>(
                 NodeType.IF,
                 FixTrueFalse.True,
                 LineRange.Invalid(),
-                new ArrayList<>()
+                label
         );
     }
 
@@ -173,12 +145,12 @@ public class VariationTreeNode extends VariationNode<VariationTreeNode> {
      * @param label a list of lines used as label
      * @see addBelow
      */
-    public static VariationTreeNode createArtifact(LineRange lineRange, List<String> label) {
-        return new VariationTreeNode(NodeType.ARTIFACT, null, lineRange, label);
+    public static <L extends Label> VariationTreeNode<L> createArtifact(LineRange lineRange, L label) {
+        return new VariationTreeNode<>(NodeType.ARTIFACT, null, lineRange, label);
     }
 
     @Override
-    public VariationTreeNode upCast() {
+    public VariationTreeNode<L> upCast() {
         return this;
     }
 
@@ -188,28 +160,17 @@ public class VariationTreeNode extends VariationNode<VariationTreeNode> {
     }
 
     @Override
-    public Label getLabel() {
+    public L getLabel() {
         return label;
     }
 
     /**
      * Replaces the current label by {@code newLabelLines}.
      *
-     * @see getLabelLines
+     * @see getLabel
      */
-    public void setLabelLines(List<String> newLabelLines) {
-        label.lines().clear();
-        addLines(newLabelLines);
-    }
-
-    /**
-     * Adds the given lines to the source code lines of this node.
-     *
-     * @param lines lines to add
-     * @see getLabelLines
-     */
-    public void addLines(final List<String> lines) {
-        this.label.lines().addAll(lines);
+    public void setLabel(L newLabel) {
+        label = newLabel;
     }
 
     @Override
@@ -223,7 +184,7 @@ public class VariationTreeNode extends VariationNode<VariationTreeNode> {
     }
 
     @Override
-    public VariationTreeNode getParent() {
+    public VariationTreeNode<L> getParent() {
         return parent;
     }
 
@@ -232,30 +193,30 @@ public class VariationTreeNode extends VariationNode<VariationTreeNode> {
      *
      * <p>This node must not have a parent yet.
      */
-    private void setParent(final VariationTreeNode newParent) {
+    private void setParent(final VariationTreeNode<L> newParent) {
         Assert.assertTrue(parent == null);
         this.parent = newParent;
     }
 
     @Override
-    public List<VariationTreeNode> getChildren() {
+    public List<VariationTreeNode<L>> getChildren() {
         return Collections.unmodifiableList(childOrder);
     }
 
     @Override
-    public void addChild(final VariationTreeNode child) {
+    public void addChild(final VariationTreeNode<L> child) {
         child.setParent(this);
         childOrder.add(child);
     }
 
     @Override
-    public void insertChild(final VariationTreeNode child, int index) {
+    public void insertChild(final VariationTreeNode<L> child, int index) {
         child.setParent(this);
         childOrder.add(index, child);
     }
 
     @Override
-    public void removeChild(final VariationTreeNode child) {
+    public void removeChild(final VariationTreeNode<L> child) {
         Assert.assertTrue(isChild(child));
         child.parent = null;
         childOrder.remove(child);
@@ -312,7 +273,7 @@ public class VariationTreeNode extends VariationNode<VariationTreeNode> {
      * @param label the label the node should have
      * @return the reconstructed node
      */
-    public static VariationTreeNode fromID(int id, List<String> label) {
+    public static <L extends Label> VariationTreeNode<L> fromID(int id, L label) {
         final int nodeTypeBitmask = (1 << NodeType.getRequiredBitCount()) - 1;
         final int nodeTypeOrdinal = id & nodeTypeBitmask;
         id >>= NodeType.getRequiredBitCount();
@@ -324,7 +285,7 @@ public class VariationTreeNode extends VariationNode<VariationTreeNode> {
         final int from = id - 1;
 
         var nodeType = NodeType.values()[nodeTypeOrdinal];
-        return new VariationTreeNode(
+        return new VariationTreeNode<L>(
                 nodeType,
                 nodeType.isConditionalAnnotation() ? FixTrueFalse.True : null,
                 LineRange.SingleLine(from),
@@ -335,7 +296,7 @@ public class VariationTreeNode extends VariationNode<VariationTreeNode> {
     /**
      * Creates a deep copy of this node.
      */
-    public VariationTreeNode deepCopy() {
+    public VariationTreeNode<L> deepCopy() {
         return toVariationTree();
     }
 
@@ -350,7 +311,7 @@ public class VariationTreeNode extends VariationNode<VariationTreeNode> {
      * @param oldToNew A map that memorizes the translation of individual nodes.
      * @return A deep copy of this tree.
      */
-    public VariationTreeNode deepCopy(final Map<VariationTreeNode, VariationTreeNode> oldToNew) {
+    public VariationTreeNode<L> deepCopy(final Map<VariationTreeNode<L>, VariationTreeNode<L>> oldToNew) {
         return toVariationTree(oldToNew);
     }
 

--- a/src/test/java/BadVDiffTest.java
+++ b/src/test/java/BadVDiffTest.java
@@ -2,12 +2,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.tinylog.Logger;
-import org.variantsync.diffdetective.datasets.PatchDiffParseOptions;
 import org.variantsync.diffdetective.diff.result.DiffParseException;
 import org.variantsync.diffdetective.util.StringUtils;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.bad.BadVDiff;
-import org.variantsync.diffdetective.variation.diff.graph.FormalDiffGraph;
 import org.variantsync.diffdetective.variation.diff.parse.DiffTreeParseOptions;
 
 import java.io.IOException;
@@ -27,14 +26,14 @@ public class BadVDiffTest {
         final Path testfile = resDir.resolve(filename + ".diff");
         Logger.debug("Testing " + testfile);
 
-        final DiffTree initialVDiff = DiffTree.fromFile(testfile, new DiffTreeParseOptions(false, false));
+        final DiffTree<DiffLinesLabel> initialVDiff = DiffTree.fromFile(testfile, new DiffTreeParseOptions(false, false));
         Logger.debug("Initial:" + StringUtils.LINEBREAK + initialVDiff);
         initialVDiff.assertConsistency();
 
-        final BadVDiff badDiff = BadVDiff.fromGood(initialVDiff);
+        final BadVDiff<DiffLinesLabel> badDiff = BadVDiff.fromGood(initialVDiff);
         Logger.debug("Bad:" + StringUtils.LINEBREAK + badDiff.prettyPrint());
 
-        final DiffTree goodDiff = badDiff.toGood();
+        final DiffTree<DiffLinesLabel> goodDiff = badDiff.toGood();
         Logger.debug("Good:" + StringUtils.LINEBREAK + goodDiff);
         goodDiff.assertConsistency();
 

--- a/src/test/java/DiffTreeParserTest.java
+++ b/src/test/java/DiffTreeParserTest.java
@@ -2,9 +2,9 @@ import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.variantsync.diffdetective.datasets.PatchDiffParseOptions;
 import org.variantsync.diffdetective.diff.result.DiffParseException;
 import org.variantsync.diffdetective.util.IO;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.parse.DiffTreeParseOptions;
 import org.variantsync.diffdetective.variation.diff.parse.DiffTreeParser;
@@ -59,7 +59,7 @@ public class DiffTreeParserTest {
         var actualPath = testDir.resolve(basename + "_actual.lg");
         var expectedPath = testDir.resolve(basename + "_expected.lg");
 
-        DiffTree diffTree;
+        DiffTree<DiffLinesLabel> diffTree;
         try (var inputFile = Files.newBufferedReader(testCasePath)) {
             diffTree = DiffTreeParser.createDiffTree(
                 inputFile,
@@ -71,7 +71,7 @@ public class DiffTreeParserTest {
         }
 
         try (var output = IO.newBufferedOutputStream(actualPath)) {
-            new LineGraphExporter(new Format(new FullNodeFormat(), new ChildOrderEdgeFormat()))
+            new LineGraphExporter<>(new Format<>(new FullNodeFormat(), new ChildOrderEdgeFormat<>()))
                 .exportDiffTree(diffTree, output);
         }
 
@@ -85,7 +85,7 @@ public class DiffTreeParserTest {
             } else {
                 // Keep output files if the test failed
                 var visualizationPath = testDir.resolve("tex").resolve(basename + ".tex");
-                new TikzExporter(new Format(new FullNodeFormat(), new DefaultEdgeLabelFormat()))
+                new TikzExporter<>(new Format<>(new FullNodeFormat(), new DefaultEdgeLabelFormat<>()))
                     .exportFullLatexExample(diffTree, visualizationPath);
                 fail("The DiffTree in file " + testCasePath + " didn't parse correctly. "
                     + "Expected the content of " + expectedPath + " but got the content of " + actualPath + ". "

--- a/src/test/java/EditClassesTest.java
+++ b/src/test/java/EditClassesTest.java
@@ -1,4 +1,5 @@
 import org.junit.jupiter.api.Test;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.diff.result.DiffParseException;
 import org.variantsync.diffdetective.editclass.proposed.ProposedEditClasses;
@@ -15,7 +16,7 @@ public class EditClassesTest {
     @Test
     public void testAtomics() throws IOException, DiffParseException {
         final Path path = testDir.resolve("elementary.diff");
-        final DiffTree t = DiffTree.fromFile(path, new DiffTreeParseOptions(false, true));
+        final DiffTree<DiffLinesLabel> t = DiffTree.fromFile(path, new DiffTreeParseOptions(false, true));
         t.forAll(node -> {
             if (node.isArtifact()) {
                 assertEquals(

--- a/src/test/java/ExportTest.java
+++ b/src/test/java/ExportTest.java
@@ -1,6 +1,7 @@
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.serialize.*;
 import org.variantsync.diffdetective.variation.diff.serialize.edgeformat.DefaultEdgeLabelFormat;
@@ -22,21 +23,21 @@ public class ExportTest {
     /**
      * Format used for the test export.
      */
-    private final static Format format =
-        new Format(
-            new LineNumberFormat(),
-            new DefaultEdgeLabelFormat()
+    private final static Format<DiffLinesLabel> format =
+        new Format<>(
+            new LineNumberFormat<>(),
+            new DefaultEdgeLabelFormat<>()
         );
 
     /**
      * Format used to deserialize the test case.
      */
-    private final static LineGraphImportOptions importOptions =
-        new LineGraphImportOptions(
+    private final static LineGraphImportOptions<DiffLinesLabel> importOptions =
+        new LineGraphImportOptions<>(
             GraphFormat.DIFFTREE,
             new CommitDiffDiffTreeLabelFormat(),
-            new LabelOnlyDiffNodeFormat(),
-            new DefaultEdgeLabelFormat()
+            new LabelOnlyDiffNodeFormat<>(),
+            new DefaultEdgeLabelFormat<>()
         );
 
     public static boolean isGraphvizInstalled() throws InterruptedException {
@@ -57,7 +58,7 @@ public class ExportTest {
         var expectedPath = RESOURCE_DIR.resolve("expected.tex");
 
         // Deserialize the test case.
-        DiffTree diffTree;
+        DiffTree<DiffLinesLabel> diffTree;
         try (BufferedReader lineGraph = Files.newBufferedReader(testCasePath)) {
             diffTree = LineGraphImport.fromLineGraph(lineGraph, testCasePath, importOptions).get(0);
         }
@@ -67,7 +68,7 @@ public class ExportTest {
                 var unbufferedOutput = Files.newOutputStream(actualPath);
                 var output = new BufferedOutputStream(unbufferedOutput)
         ) {
-            new TikzExporter(format).exportDiffTree(diffTree, output);
+            new TikzExporter<>(format).exportDiffTree(diffTree, output);
         }
 
         try (

--- a/src/test/java/GitDifferTest.java
+++ b/src/test/java/GitDifferTest.java
@@ -9,6 +9,7 @@ import org.variantsync.diffdetective.diff.git.DiffFilter;
 import org.variantsync.diffdetective.diff.git.PatchDiff;
 import org.variantsync.diffdetective.diff.result.DiffParseException;
 import org.variantsync.diffdetective.util.IO;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.parse.DiffTreeParseOptions;
 import org.variantsync.diffdetective.variation.diff.parse.DiffTreeParser;
@@ -46,10 +47,10 @@ public class GitDifferTest {
             var actualPath = testDir.resolve(commitHash + "_actual.lg");
             var expectedPath = testDir.resolve(commitHash + ".lg");
 
-            DiffTree diffTree = patch.getDiffTree();
+            DiffTree<DiffLinesLabel> diffTree = patch.getDiffTree();
 
             try (var output = IO.newBufferedOutputStream(actualPath)) {
-                new LineGraphExporter(new Format(new FullNodeFormat(), new ChildOrderEdgeFormat()))
+                new LineGraphExporter<>(new Format<>(new FullNodeFormat(), new ChildOrderEdgeFormat<>()))
                         .exportDiffTree(diffTree, output);
             }
 

--- a/src/test/java/LineGraphTest.java
+++ b/src/test/java/LineGraphTest.java
@@ -1,6 +1,7 @@
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.serialize.*;
 import org.variantsync.diffdetective.variation.diff.serialize.edgeformat.DefaultEdgeLabelFormat;
@@ -22,13 +23,13 @@ import java.util.stream.Stream;
  * For testing the import of a line graph.
  */
 public class LineGraphTest {
-	private final static LineGraphImportOptions IMPORT_OPTIONS = new LineGraphImportOptions(
+	private final static LineGraphImportOptions<DiffLinesLabel> IMPORT_OPTIONS = new LineGraphImportOptions<>(
             GraphFormat.DIFFTREE,
             new CommitDiffDiffTreeLabelFormat(),
-            new LabelOnlyDiffNodeFormat(),
-            new DefaultEdgeLabelFormat()
+            new LabelOnlyDiffNodeFormat<>(),
+            new DefaultEdgeLabelFormat<>()
     );
-    private final static LineGraphExportOptions EXPORT_OPTIONS = new LineGraphExportOptions(
+    private final static LineGraphExportOptions<DiffLinesLabel> EXPORT_OPTIONS = new LineGraphExportOptions<>(
             IMPORT_OPTIONS
     );
 
@@ -42,7 +43,7 @@ public class LineGraphTest {
     @ParameterizedTest
     @MethodSource("testCases")
     public void idempotentReadWrite(Path testFile) throws IOException {
-        List<DiffTree> diffTrees;
+        List<DiffTree<DiffLinesLabel>> diffTrees;
         try (BufferedReader lineGraph = Files.newBufferedReader(testFile)) {
             diffTrees = LineGraphImport.fromLineGraph(lineGraph, testFile, IMPORT_OPTIONS);
         }
@@ -71,7 +72,7 @@ public class LineGraphTest {
 	 * 
 	 * @param treeList {@link DiffTree} list
 	 */
-	private static void assertConsistencyForAll(final List<DiffTree> treeList) {
+	private static void assertConsistencyForAll(final List<DiffTree<DiffLinesLabel>> treeList) {
 //        for (final DiffTree t : treeList) {
 //            DiffTreeRenderer.WithinDiffDetective().render(t, t.getSource().toString(), Path.of("error"), PatchDiffRenderer.ErrorDiffTreeRenderOptions);
 //        }

--- a/src/test/java/LinuxParsingTest.java
+++ b/src/test/java/LinuxParsingTest.java
@@ -1,3 +1,4 @@
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.parse.DiffTreeParseOptions;
 import org.variantsync.diffdetective.variation.diff.render.DiffTreeRenderer;
@@ -15,7 +16,7 @@ public class LinuxParsingTest {
     public void test1() throws IOException, DiffParseException {
         final String testFilename = "test1.diff";
         final Path path = testDir.resolve(testFilename);
-        final DiffTree t = DiffTree.fromFile(path, new DiffTreeParseOptions(false, true));
+        final DiffTree<DiffLinesLabel> t = DiffTree.fromFile(path, new DiffTreeParseOptions(false, true));
 
 //        new FeatureExpressionFilter(LinuxKernel::isFeature).transform(t);
 

--- a/src/test/java/MarlinDebug.java
+++ b/src/test/java/MarlinDebug.java
@@ -13,6 +13,7 @@ import org.variantsync.diffdetective.datasets.PatchDiffParseOptions;
 import org.variantsync.diffdetective.datasets.Repository;
 import org.variantsync.diffdetective.diff.git.CommitDiff;
 import org.variantsync.diffdetective.diff.git.PatchDiff;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.parse.DiffTreeParser;
 import org.variantsync.diffdetective.variation.diff.parse.IllFormedAnnotationException;
@@ -92,12 +93,12 @@ public class MarlinDebug {
         Clock clock = new Clock();
         final CommitDiff commitDiff = DiffTreeParser.parseCommit(repoInspection.repo, commitHash);
         Logger.info("  Done after {}", clock.printPassedSeconds());
-        final List<DiffTreeTransformer> transform = DiffTreeMiner.Postprocessing(repoInspection.repo);
+        final List<DiffTreeTransformer<DiffLinesLabel>> transform = DiffTreeMiner.Postprocessing(repoInspection.repo);
 
         for (final PatchDiff patch : commitDiff.getPatchDiffs()) {
             if (patch.isValid()) {
                 Logger.info("  Begin processing {}", patch);
-                final DiffTree t = patch.getDiffTree();
+                final DiffTree<DiffLinesLabel> t = patch.getDiffTree();
                 Logger.info("    Begin transform");
                 clock.start();
                 DiffTreeTransformer.apply(transform, t);

--- a/src/test/java/MoveDetectionTest.java
+++ b/src/test/java/MoveDetectionTest.java
@@ -1,4 +1,4 @@
-import org.variantsync.diffdetective.datasets.PatchDiffParseOptions;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.parse.DiffTreeParseOptions;
 import org.variantsync.diffdetective.variation.diff.render.DiffTreeRenderer;
@@ -14,10 +14,10 @@ public class MoveDetectionTest {
 
 //    @Test
     public void simpleTest() throws IOException, DiffParseException {
-        final DiffTree t = DiffTree.fromFile(resDir.resolve("simple.txt"), new DiffTreeParseOptions(true, true));
+        final DiffTree<DiffLinesLabel> t = DiffTree.fromFile(resDir.resolve("simple.txt"), new DiffTreeParseOptions(true, true));
         final DiffTreeRenderer renderer = DiffTreeRenderer.WithinDiffDetective();
         renderer.render(t, "MoveDetectionTestSimpleTest_Before", genDir);
-        new NaiveMovedArtifactDetection().transform(t);
+        new NaiveMovedArtifactDetection<DiffLinesLabel>().transform(t);
         renderer.render(t, "MoveDetectionTestSimpleTest_After", genDir);
     }
 }

--- a/src/test/java/PCTest.java
+++ b/src/test/java/PCTest.java
@@ -5,6 +5,7 @@ import org.prop4j.Literal;
 import org.prop4j.Node;
 import org.tinylog.Logger;
 import org.variantsync.diffdetective.analysis.logic.SAT;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.diff.result.DiffParseException;
 import org.variantsync.diffdetective.variation.diff.parse.DiffTreeParseOptions;
@@ -72,7 +73,7 @@ public class PCTest {
     @MethodSource("testCases")
     public void test(final TestCase testCase) throws IOException, DiffParseException {
         final Path path = testDir.resolve(testCase.file);
-        final DiffTree t = DiffTree.fromFile(path, new DiffTreeParseOptions(false, true));
+        final DiffTree<DiffLinesLabel> t = DiffTree.fromFile(path, new DiffTreeParseOptions(false, true));
         t.forAll(node -> {
            if (node.isArtifact()) {
                final String text = node.getLabel().toString().trim();

--- a/src/test/java/StarfoldTest.java
+++ b/src/test/java/StarfoldTest.java
@@ -1,6 +1,7 @@
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.parse.DiffTreeParseOptions;
 import org.variantsync.diffdetective.variation.diff.transform.Starfold;
@@ -22,7 +23,7 @@ public class StarfoldTest {
     }
 
     private void test(Path inputDiff, final Starfold starfold, Path expected) throws IOException, DiffParseException {
-        final DiffTree t = DiffTree.fromFile(inputDiff, new DiffTreeParseOptions(true, true));
+        final DiffTree<DiffLinesLabel> t = DiffTree.fromFile(inputDiff, new DiffTreeParseOptions(true, true));
         starfold.transform(t);
 
         // missing: Check that t is correct.

--- a/src/test/java/TestLineNumbers.java
+++ b/src/test/java/TestLineNumbers.java
@@ -73,7 +73,7 @@ public class TestLineNumbers {
     private static void printLineNumbers(final DiffTree<DiffLinesLabel> diffTree) {
         diffTree.forAll(node ->
                 System.out.println(node.diffType.symbol
-                    + " " + node.nodeType
+                    + " " + node.getNodeType()
                     + " \"" + node.getLabel().toString().trim()
                     + " with ID " + node.getID()
                     + "\" old: " + node.getLinesAtTime(BEFORE)

--- a/src/test/java/TestLineNumbers.java
+++ b/src/test/java/TestLineNumbers.java
@@ -1,7 +1,7 @@
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.variantsync.diffdetective.datasets.PatchDiffParseOptions;
 import org.variantsync.diffdetective.diff.text.DiffLineNumber;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.diff.result.DiffParseException;
 import org.variantsync.diffdetective.variation.diff.parse.DiffTreeParseOptions;
@@ -64,13 +64,13 @@ public class TestLineNumbers {
         return List.of(elifchain, lineno1, deleteMLM);
     }
 
-    private static DiffTree loadFullDiff(final Path p) throws IOException, DiffParseException {
+    private static DiffTree<DiffLinesLabel> loadFullDiff(final Path p) throws IOException, DiffParseException {
         return DiffTree.fromFile(p, new DiffTreeParseOptions(
                 false, false
         ));
     }
 
-    private static void printLineNumbers(final DiffTree diffTree) {
+    private static void printLineNumbers(final DiffTree<DiffLinesLabel> diffTree) {
         diffTree.forAll(node ->
                 System.out.println(node.diffType.symbol
                     + " " + node.nodeType
@@ -84,7 +84,7 @@ public class TestLineNumbers {
     }
 
     private static String generateTestCaseCode(final Path p) throws IOException, DiffParseException {
-        final DiffTree diffTree = loadFullDiff(p);
+        final DiffTree<DiffLinesLabel> diffTree = loadFullDiff(p);
         final Function<DiffLineNumber, String> toConstructorCall = l ->
                 "new DiffLineNumber(" + l.inDiff() + ", " + l.beforeEdit() + ", " + l.afterEdit() + ")";
         String testName = p.getFileName().toString();
@@ -131,7 +131,7 @@ public class TestLineNumbers {
     @ParameterizedTest
     @MethodSource("testCases")
     public void testLineNumbers(TestCase testCase) throws IOException, DiffParseException {
-        final DiffTree t = loadFullDiff(resDir.resolve(testCase.filename()));
+        final DiffTree<DiffLinesLabel> t = loadFullDiff(resDir.resolve(testCase.filename()));
         t.forAll(node -> {
             var fromTo = testCase.expectedLineNumbers.get(node.getID());
             final DiffLineNumber from = fromTo.first();

--- a/src/test/java/TestMultiLineMacros.java
+++ b/src/test/java/TestMultiLineMacros.java
@@ -1,6 +1,7 @@
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.tinylog.Logger;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.feature.CPPAnnotationParser;
 import org.variantsync.diffdetective.variation.diff.parse.DiffTreeParseOptions;
@@ -26,8 +27,8 @@ import java.nio.file.Path;
 public class TestMultiLineMacros {
     private static final Path resDir = Constants.RESOURCE_DIR.resolve("multilinemacros");
 
-    public void diffToDiffTree(LineGraphExportOptions exportOptions, Path p) throws IOException, DiffParseException {
-        DiffTree tree;
+    public void diffToDiffTree(LineGraphExportOptions<DiffLinesLabel> exportOptions, Path p) throws IOException, DiffParseException {
+        DiffTree<DiffLinesLabel> tree;
         try (BufferedReader fullDiff = Files.newBufferedReader(p)) {
             tree = DiffTreeParser.createDiffTree(
                     fullDiff,
@@ -53,11 +54,11 @@ public class TestMultiLineMacros {
     @ParameterizedTest
     @ValueSource(strings = { "mldiff1.txt", "diffWithComments.txt" })
     public void test(String filename) throws IOException, DiffParseException {
-        final LineGraphExportOptions exportOptions = new LineGraphExportOptions(
+        final LineGraphExportOptions<DiffLinesLabel> exportOptions = new LineGraphExportOptions<>(
                 GraphFormat.DIFFTREE,
                 new CommitDiffDiffTreeLabelFormat(),
-                new DebugDiffNodeFormat(),
-                new DefaultEdgeLabelFormat()
+                new DebugDiffNodeFormat<>(),
+                new DefaultEdgeLabelFormat<>()
         );
 
         diffToDiffTree(exportOptions, resDir.resolve(filename));

--- a/src/test/java/TreeDiffingTest.java
+++ b/src/test/java/TreeDiffingTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.variantsync.diffdetective.diff.result.DiffParseException;
 import org.variantsync.diffdetective.feature.CPPAnnotationParser;
 import org.variantsync.diffdetective.util.IO;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.Construction;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.parse.DiffTreeParseOptions;
@@ -76,13 +77,13 @@ public class TreeDiffingTest {
     @ParameterizedTest
     @MethodSource("testCases")
     public void testCase(TestCase testCase) throws IOException, DiffParseException {
-        VariationTree beforeEdit = parseVariationTree(testCase.beforeEdit());
-        VariationTree afterEdit = parseVariationTree(testCase.afterEdit());
+        VariationTree<DiffLinesLabel> beforeEdit = parseVariationTree(testCase.beforeEdit());
+        VariationTree<DiffLinesLabel> afterEdit = parseVariationTree(testCase.afterEdit());
 
-        DiffTree diffTree = Construction.diffUsingMatching(beforeEdit, afterEdit);
+        DiffTree<DiffLinesLabel> diffTree = Construction.diffUsingMatching(beforeEdit, afterEdit);
 
         try (var output = IO.newBufferedOutputStream(testCase.actual())) {
-            new LineGraphExporter(new Format(new FullNodeFormat(), new ChildOrderEdgeFormat()))
+            new LineGraphExporter<>(new Format<>(new FullNodeFormat(), new ChildOrderEdgeFormat<>()))
                 .exportDiffTree(diffTree, output);
         }
 
@@ -95,7 +96,7 @@ public class TreeDiffingTest {
                 Files.delete(testCase.actual());
             } else {
                 // Keep output files if the test failed
-                new TikzExporter(new Format(new FullNodeFormat(), new DefaultEdgeLabelFormat()))
+                new TikzExporter<>(new Format<>(new FullNodeFormat(), new DefaultEdgeLabelFormat<>()))
                     .exportFullLatexExample(diffTree, testCase.visualisation());
                 fail(String.format(
                     "The diff of %s and %s is not as expected. " +
@@ -111,9 +112,9 @@ public class TreeDiffingTest {
         }
     }
 
-    public VariationTree parseVariationTree(Path filename) throws IOException, DiffParseException {
+    public VariationTree<DiffLinesLabel> parseVariationTree(Path filename) throws IOException, DiffParseException {
         try (var file = Files.newBufferedReader(filename)) {
-            return new VariationTree(
+            return new VariationTree<>(
                 DiffTreeParser.createVariationTree(
                     file,
                     new DiffTreeParseOptions(

--- a/src/test/java/TreeTransformersTest.java
+++ b/src/test/java/TreeTransformersTest.java
@@ -1,12 +1,12 @@
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.variantsync.diffdetective.datasets.PatchDiffParseOptions;
 import org.variantsync.diffdetective.datasets.Repository;
 import org.variantsync.diffdetective.datasets.predefined.StanciulescuMarlin;
 import org.variantsync.diffdetective.diff.git.PatchDiff;
 import org.variantsync.diffdetective.diff.result.DiffParseException;
 import org.variantsync.diffdetective.mining.DiffTreeMiner;
+import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.diff.DiffTree;
 import org.variantsync.diffdetective.variation.diff.parse.DiffTreeParseOptions;
 import org.variantsync.diffdetective.variation.diff.parse.DiffTreeParser;
@@ -31,11 +31,11 @@ public class TreeTransformersTest {
     private static final boolean RENDER = true;
     private static final Path resDir = Constants.RESOURCE_DIR.resolve("diffs/collapse");
     private static final Path genDir = resDir.resolve("gen");
-    private static final RenderOptions renderOptions = new RenderOptions(
+    private static final RenderOptions<DiffLinesLabel> renderOptions = new RenderOptions<>(
             GraphFormat.DIFFTREE,
             new CommitDiffDiffTreeLabelFormat(),
-            new TypeDiffNodeFormat(),
-            new DefaultEdgeLabelFormat(),
+            new TypeDiffNodeFormat<>(),
+            new DefaultEdgeLabelFormat<>(),
             false,
             500,
             50,
@@ -49,11 +49,11 @@ public class TreeTransformersTest {
     private static final Consumer<String> INFO = System.out::println;
 
     private void transformAndRender(String diffFileName) throws IOException, DiffParseException {
-        final DiffTree t = DiffTree.fromFile(resDir.resolve(diffFileName), new DiffTreeParseOptions(true, true));
+        final DiffTree<DiffLinesLabel> t = DiffTree.fromFile(resDir.resolve(diffFileName), new DiffTreeParseOptions(true, true));
         transformAndRender(t, diffFileName, "0", null);
     }
 
-    private void transformAndRender(DiffTree diffTree, String name, String commit, Repository repository) {
+    private void transformAndRender(DiffTree<DiffLinesLabel> diffTree, String name, String commit, Repository repository) {
         final DiffTreeRenderer renderer = DiffTreeRenderer.WithinDiffDetective();
         final String treeName = name + LineGraphConstants.TREE_NAME_SEPARATOR + commit;
 
@@ -64,8 +64,8 @@ public class TreeTransformersTest {
 
         int i = 1;
         int prevSize = diffTree.computeSize();
-        final List<DiffTreeTransformer> transformers = DiffTreeMiner.Postprocessing(repository);
-        for (final DiffTreeTransformer f : transformers) {
+        final List<DiffTreeTransformer<DiffLinesLabel>> transformers = DiffTreeMiner.Postprocessing(repository);
+        for (final DiffTreeTransformer<DiffLinesLabel> f : transformers) {
             INFO.accept("Applying transformation " + f + ".");
             f.transform(diffTree);
 


### PR DESCRIPTION
These commits allow for variation trees whose variants are also variation trees (e.g. the variants of `VariationTree<VariationLabel<LinesLabel>>` are `VariationTree<LinesLabel>`). Currently, there are no methods to create such nested variation trees. These will follow in a separate pull request.