### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ DiffDetective is an open-source Java library for variability-aware source code d
 
 <img alt="Variability-Aware Differencing Overview" src="docs/teaser.png" height="500" />
 
-Given two states of a C-preprocessor annotated source code file (left), for example before and after a commit, DiffDetective constructs a variability-aware diff (right) that distinguishes changes to source code from canges to variability annotations. DiffDetective can construct such a variation diff either, by first using a generic differencer, and separating the information (center path), or by first parsing both input versions to an abstract representation, a variation tree (center top and bottom), and constructing a variation diff using a tree differencing algorithm in a second step.
+Given two states of a C-preprocessor annotated source code file (left), for example before and after a commit, DiffDetective constructs a variability-aware diff (right) that distinguishes changes to source code from changes to variability annotations. DiffDetective can construct such a variation diff either, by first using a generic differencer, and separating the information (center path), or by first parsing both input versions to an abstract representation, a variation tree (center top and bottom), and constructing a variation diff using a tree differencing algorithm in a second step.
 
 Additionally, DiffDetective offers a **flexible framework for large-scale empirical analyses of git version histories** of statically configurable software. In multiple studies, DiffDetective was successfully employed to study the commit histories of up to 44 open-source git repositories, including the **Linux Kernel, GCC, Vim, Emacs, or the Godot game engine**.
 
@@ -58,7 +58,7 @@ You can (re-)produce this jar file by either running `mvn package` or `mvn insta
 
 #### Building with Nix
 
-Alternatively to manual building using Maven, Nix can be used. Both a [flake.nix](flake.nix) and a [default.nix](default.nix) are provided. Hence, you can build DiffDetective using
+Alternatively to manually building using Maven, Nix can be used. Both a [flake.nix](flake.nix) and a [default.nix](default.nix) are provided. Hence, you can build DiffDetective using
 ```shell
 nix-build # stable version
 # or
@@ -66,7 +66,7 @@ nix build # Flake version
 ```
 In case you are using Nix Flakes, you can skip cloning the repository as usual: `nix build github:VariantSync/DiffDetective#.`
 
-Afterwards, the [result](result) symlink points to the [Javadoc](result/share/github-pages/docs/javadoc/index.html), the [DiffDetective jar](result/share/java/DiffDetective/DiffDetective.jar) and a simple [script](result/bin/DiffDetective) for executing a DiffDetective main class provided as argument (e.g., evaluations used in previous research).
+Afterward, the [result](result) symlink points to the [Javadoc](result/share/github-pages/docs/javadoc/index.html), the [DiffDetective jar](result/share/java/DiffDetective/DiffDetective.jar) and a simple [script](result/bin/DiffDetective) for executing a DiffDetective main class provided as argument (e.g., evaluations used in previous research, see below under 'Publications').
 
 ## Publications
 
@@ -88,7 +88,7 @@ In particular, we used DiffDetective to classify the effect of edits on the vari
 
 The classification is implemented within the [org.variantsync.diffdetective.editclass](src/main/java/org/variantsync/diffdetective/editclass/) package.
 
-The original replication package can be found on the [esecfse](https://github.com/VariantSync/DiffDetective/tree/esecfse22) branch or via the DOI [10.5281/zenodo.7110095](https://doi.org/10.5281/zenodo.7110095). The replication is also available for the most recent version of DiffDetective with various improvements, which will likely yield to slightly different results than the initial study. The updated replication package can be found in the [replication/esecfse22](replication/esecfse22) subdirectory with it's own [README](replication/esecfse22/README.md).
+The original replication package can be found on the [esecfse](https://github.com/VariantSync/DiffDetective/tree/esecfse22) branch or via the DOI [10.5281/zenodo.7110095](https://doi.org/10.5281/zenodo.7110095). The replication is also available for the most recent version of DiffDetective with various improvements, which will likely yield to slightly different results than the initial study. The updated replication package can be found in the [replication/esecfse22](replication/esecfse22) subdirectory with its own [README](replication/esecfse22/README.md).
 
 
 ### Views on Edits to Variational Software (SPLC 2023)
@@ -125,7 +125,7 @@ The original replication package can be found on the `splc23-views` branch withi
 
 <img padding="10" align="right" src="https://www.acm.org/binaries/content/gallery/acm/publications/artifact-review-v1_1-badges/artifacts_evaluated_functional_v1_1.png" alt="ACM Artifacts Evaluated Reusable" width="114" height="113"/>
 
-In this work, we formalized an extension of variation diffs, with a typing for edges and pair-wise relations for variability annotations (i.e., mapping nodes in variation diffs). Such edge-typed variation diffs show for example that two annotations exlude or imply each other. Such edge-typed diffs might help better explaining or analyzing edits in the future.
+In this work, we formalized an extension of variation diffs, with a typing for edges and pair-wise relations for variability annotations (i.e., mapping nodes in variation diffs). Such edge-typed variation diffs show for example that two annotations exclude or imply each other. Such edge-typed diffs might help better explaining or analyzing edits in the future.
 
 Edge-typed variation diffs and the replication package are implemented in a fork of DiffDetective ([https://github.com/guethilu/DiffDetective][forklg]). The replication package is archived under the DOI [10.5281/zenodo.10286851](https://doi.org/10.5281/zenodo.10286851).
 

--- a/README.md
+++ b/README.md
@@ -16,32 +16,32 @@ Additionally, DiffDetective offers a **flexible framework for large-scale empiri
 
 ## Setup
 
-DiffDetective is a Java Maven library. While DiffDetective depends on some custom libraries ([FeatureIDE library](https://featureide.github.io/), [Sat4j](https://sat4j.org/), [Functjonal](https://github.com/VariantSync/Functjonal)) these are prepackaged with DiffDetective. So **all you need is [Maven](https://maven.apache.org/)** installed.
+DiffDetective is a Java Maven library. While DiffDetective depends on some custom libraries ([FeatureIDE library](https://featureide.github.io/), [Sat4j](https://sat4j.org/), [Functjonal](https://github.com/VariantSync/Functjonal)) these are prepackaged with DiffDetective. So **all you need is Java ≥16 and [Maven](https://maven.apache.org/) or alternatively [Nix](https://nixos.org/)**. In the following, we explain the setup with Java and Maven, as well as via Nix.
 
-DiffDetective also comes as a **nix package** (see [default.nix](default.nix)).
+### Cloning the Repository
 
-### Cloning the repository
-
-First, clone this repository and navigate inside it:
+Clone this repository and navigate inside it:
 ```shell
 git clone https://github.com/VariantSync/DiffDetective
 cd DiffDetective
 ```
 
-### Building and installing
+> In case you are using Nix Flakes, you may skip cloning the repository.
 
-You can build and install DiffDetective using Maven such that it can be used in your own `pom.xml`. Alternatively, you can use a jar which includes all necessary dependencies. Such a jar can either be built manually using Maven or using Nix.
+### Building and Installing
 
-#### Building and installing with Maven
+You can build and install DiffDetective with Maven such that it can be used in your own project. Alternatively, you can use a jar which includes all necessary dependencies. Such a jar can either be built manually using Maven or using Nix.
 
-For building and installing Maven needs to be installed. Either provide it yourselves (e.g., using the system package manager) or, if you have Nix installed, run `nix-shell` (stable Nix) or `nix develop` (Nix Flakes) to provide all necessary build tools.
+#### Building and Installing With Maven
+
+First, Maven needs to be installed. Either provide it yourself (e.g., using a system package manager or on Windows, download [from their website](https://maven.apache.org/guides/getting-started/windows-prerequisites.html)) or, if you have Nix installed, run `nix-shell` (stable Nix) or `nix develop` (Nix Flakes) to provide all necessary build tools.
 
 Next, build DiffDetective and install it on your system so that you can access it from your own projects:
 ```shell
 mvn install
 ```
 
-DiffDetective is now available on your system. Add the following to the pom.xml of your Maven project to add DiffDetective as a dependency, but make sure to pick the right version number. You can find the version number of DiffDetective at the top of the pom.xml file of DiffDetective. 
+To add DiffDetective as a dependency to your own project, add the following snippet to the pom.xml of your Maven project, but make sure to pick the right version number. You can find the version number of DiffDetective at the top of the pom.xml file of DiffDetective. 
 
 ```xml
 <dependency>
@@ -51,7 +51,7 @@ DiffDetective is now available on your system. Add the following to the pom.xml 
 </dependency>
 ```
 
-If you prefer to just use a jar file, you can find a jar file with all dependencies in `DiffDetective/target/diffdetective-2.0.0-jar-with-dependencies.jar` (again, the version number might be different).
+If you prefer to just use a jar file, you can find a jar file with all dependencies at `DiffDetective/target/diffdetective-2.0.0-jar-with-dependencies.jar` (again, the version number might be different).
 You can (re-)produce this jar file by either running `mvn package` or `mvn install` within you local clone of DiffDetective.
 
 > Disclaimer: Setup tested with maven version 3.6.3.
@@ -87,6 +87,7 @@ This was the initial work, introducing DiffDetective as a means to conduct an em
 In particular, we used DiffDetective to classify the effect of edits on the variability of the edited source code in the change histories of 44 open-source C-preprocessor-based software projects.
 
 The classification is implemented within the [org.variantsync.diffdetective.editclass](src/main/java/org/variantsync/diffdetective/editclass/) package.
+The empirical evaluation of the classification, including a respective `main` method, is implemented in the [org.variantsync.diffdetective.experiments.esecfse22](src/main/java/org/variantsync/diffdetective/experiments/esecfse22) package.
 
 The original replication package can be found on the [esecfse](https://github.com/VariantSync/DiffDetective/tree/esecfse22) branch or via the DOI [10.5281/zenodo.7110095](https://doi.org/10.5281/zenodo.7110095). The replication is also available for the most recent version of DiffDetective with various improvements, which will likely yield to slightly different results than the initial study. The updated replication package can be found in the [replication/esecfse22](replication/esecfse22) subdirectory with its own [README](replication/esecfse22/README.md).
 
@@ -110,6 +111,7 @@ A view on an edit thus is a simplified form of an edit that, for example, contai
 From a mathematical perspective, creating such views is in fact a lifting of operations on single revisions of variational systems to operations on diffs of variational systems.
 
 Views are implemented within the [org.variantsync.diffdetective.variation.tree.view](src/main/java/org/variantsync/diffdetective/variation/tree/view/) and [org.variantsync.diffdetective.variation.diff.view](src/main/java/org/variantsync/diffdetective/variation/diff/view/) packages for variaton trees and diffs, respectively.
+The empirical evaluation of the view algorithms, including a respective `main` method, is implemented in the [org.variantsync.diffdetective.experiments.views](src/main/java/org/variantsync/diffdetective/experiments/views) package.
 
 The original replication package can be found on the `splc23-views` branch within the directory [replication/splc23-views](https://github.com/VariantSync/DiffDetective/tree/splc23-views/replication/splc23-views) or via the DOI [10.5281/zenodo.8027920](https://doi.org/10.5281/zenodo.8027920). The replication is also available for the most recent version of DiffDetective with an up-to-date version of DiffDetective, which will likely yield to slightly different results than the initial study. The updated replication package can be found in the [replication/splc23-views](replication/splc23-views) subdirectory with it's own [README](replication/splc23-views/README.md).
 
@@ -133,7 +135,7 @@ Edge-typed variation diffs and the replication package are implemented in a fork
 
 DiffDetective was extended and used within bachelor's and master's theses:
 
-- _Constructing Variation Diffs Using Tree Diffing Algorithms_, Benjamin Moosherr, Bachelor's Thesis, 2023, [DOI 10.18725/OPARU-50108](https://dx.doi.org/10.18725/OPARU-50108): Benjamin added support for tree-differencing and integrated the GumTree differencer ([Github](https://github.com/GumTreeDiff/gumtree), [Paper](https://doi.org/10.1145/2642937.2642982)). In his thesis, Benjamin also reviewed a range of quality metrics for tree-diffs with focus on their applicability for rating variability-aware diffs.
+- _Constructing Variation Diffs Using Tree Diffing Algorithms_, Benjamin Moosherr, Bachelor's Thesis, 2023, [DOI 10.18725/OPARU-50108](https://dx.doi.org/10.18725/OPARU-50108): Benjamin added support for tree-differencing and integrated the GumTree differencer ([Github](https://github.com/GumTreeDiff/gumtree), [Paper](https://doi.org/10.1145/2642937.2642982)). In his thesis, Benjamin also reviewed a range of quality metrics for tree-diffs with focus on their applicability for rating variability-aware diffs. The [org.variantsync.diffdetective.experiments.thesis_bm](src/main/java/org/variantsync/diffdetective/experiments/thesis_bm) package implements the corresponding empirical study and may serve as an example on how to use the tree-differencing.
 - _Reverse Engineering Feature-Aware Commits From Software Product-Line Repositories_, Lukas Bormann, Bachelor's Thesis, 2023, [10.18725/OPARU-47892](https://dx.doi.org/10.18725/OPARU-47892): Lukas implemented an algorithm for feature-based commit-untangling, which turns variation diff into a series of smaller diffs, each of which contains an edit to a single feature or feature formula. This work was later refined in our publication _Views on Edits to Variational Software_ illustrated above.
 - _Inspecting the Evolution of Feature Annotations in Configurable Software_, Lukas Güthing, Master's Thesis, 2023: Lukas implemented different edge-types for associating variability annotations within variation diffs. He published his work later at VaMoS 2024 under the title _Explaining Edits to Variability Annotations in Evolving Software Product Lines_, illustrated above.
 - _Empirical Evaluation of Feature Trace Recording on the Edit History of Marlin_, Sören Viegener, Bachelor's Thesis, 2021, [DOI 10.18725/OPARU-38603](http://dx.doi.org/10.18725/OPARU-38603): In his thesis, Sören started the DiffDetective project and implemented the first version of an algorithm, which parses text-based diffs to C-preprocessor files to variation diffs. He also came up with an initial classification of edits, which we wanted to reuse to evaluate [Feature Trace Recording](https://variantsync.github.io/FeatureTraceRecording/), a method for deriving variability annotations from annotated patches.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Second, build DiffDetective and install it on your system so that you can access
 mvn install
 ```
 
-DiffDetective is now available on your system. Add the following to the pom.xml of your Maven project to add DiffDetective as a dependency, but make sure to pick the right version. You can the current version of DiffDetective you installed at the top of the pom.xml file in DiffDetective. 
+DiffDetective is now available on your system. Add the following to the pom.xml of your Maven project to add DiffDetective as a dependency, but make sure to pick the right version number. You can find the version number of DiffDetective at the top of the pom.xml file of DiffDetective. 
 
 ```xml
 <dependency>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ DiffDetective is a Java Maven library. While DiffDetective depends on some custo
 
 DiffDetective also comes as a **nix package** (see [default.nix](default.nix)).
 
-### Setup with Maven
+### Cloning the repository
 
 First, clone this repository and navigate inside it:
 ```shell
@@ -28,7 +28,15 @@ git clone https://github.com/VariantSync/DiffDetective
 cd DiffDetective
 ```
 
-Second, build DiffDetective and install it on your system so that you can access it from your own projects:
+### Building and installing
+
+You can build and install DiffDetective using Maven such that it can be used in your own `pom.xml`. Alternatively, you can use a jar which includes all necessary dependencies. Such a jar can either be built manually using Maven or using Nix.
+
+#### Building and installing with Maven
+
+For building and installing Maven needs to be installed. Either provide it yourselves (e.g., using the system package manager) or, if you have Nix installed, run `nix-shell` (stable Nix) or `nix develop` (Nix Flakes) to provide all necessary build tools.
+
+Next, build DiffDetective and install it on your system so that you can access it from your own projects:
 ```shell
 mvn install
 ```
@@ -47,6 +55,18 @@ If you prefer to just use a jar file, you can find a jar file with all dependenc
 You can (re-)produce this jar file by either running `mvn package` or `mvn install` within you local clone of DiffDetective.
 
 > Disclaimer: Setup tested with maven version 3.6.3.
+
+#### Building with Nix
+
+Alternatively to manual building using Maven, Nix can be used. Both a [flake.nix](flake.nix) and a [default.nix](default.nix) are provided. Hence, you can build DiffDetective using
+```shell
+nix-build # stable version
+# or
+nix build # Flake version
+```
+In case you are using Nix Flakes, you can skip cloning the repository as usual: `nix build github:VariantSync/DiffDetective#.`
+
+Afterwards, the [result](result) symlink points to the [Javadoc](result/share/github-pages/docs/javadoc/index.html), the [DiffDetective jar](result/share/java/DiffDetective/DiffDetective.jar) and a simple [script](result/bin/DiffDetective) for executing a DiffDetective main class provided as argument (e.g., evaluations used in previous research).
 
 ## Publications
 

--- a/README.md
+++ b/README.md
@@ -4,19 +4,21 @@
 [![GitHubPages](https://img.shields.io/badge/GitHub%20Pages-online-blue.svg?style=flat)][website]
 [![License](https://img.shields.io/badge/License-GNU%20LGPLv3-blue)](LICENSE.LGPL3)
 
-# DiffDetective - Analysing Edits to Preprocessor-Based Variability
+# DiffDetective - Variability-Aware Source Code Differencing
 
-DiffDetective is a research software to study the evolution of configurable and variational software projects, also known as software product lines.
+DiffDetective is an open-source Java library for variability-aware source code differencing and the **analysis of version histories of software product lines**. This means that DiffDetective can **turn a generic differencer into a variability-aware differencer** by means of a pre- or post-processing. DiffDetective is centered around **formally verified** data structures for variability (variation trees) and variability-aware diffs (variation diffs). These data structures are **generic**, and DiffDetective currently implements **C preprocessor support** to parse respective annotations when used to implement variability. The picture below depicts the process of variability-aware differencing.
 
-DiffDetective reads the Git history of a C-preprocessor-based software product line to analyze patches in terms of _variation diffs_.
-A variation diff is a graph that depicts changes to source code as well as to variability annotations (e.g., C-preprocessor macros such as `#if` and `#ifdef`).
+<img alt="Variability-Aware Differencing Overview" src="docs/teaser.png" height="500" />
 
-![DiffDetectiveTeaser](docs/teaser.png)
+Given two states of a C-preprocessor annotated source code file (left), for example before and after a commit, DiffDetective constructs a variability-aware diff (right) that distinguishes changes to source code from canges to variability annotations. DiffDetective can construct such a variation diff either, by first using a generic differencer, and separating the information (center path), or by first parsing both input versions to an abstract representation, a variation tree (center top and bottom), and constructing a variation diff using a tree differencing algorithm in a second step.
 
-This figure outlines the parsing process within DiffDetective.
-Given two states of a C-preprocessor annotated source code file (left), for example before and after a commit, DiffDetective constructs a variation diff (right) that describes the differences of the code as well as the involved variability.
-DiffDetective can construct a variation diff either from a text-based diff between both file versions (center path),
-or by first parsing both versions to an abstract representation, a variation tree (center top and bottom), and constructing a variation diff using a tree matching algorithm in a second step.
+Additionally, DiffDetective offers a **flexible framework for large-scale empirical analyses of git version histories** of statically configurable software. In multiple studies, DiffDetective was successfully employed to study the commit histories of up to 44 open-source git repositories, including the **Linux Kernel, GCC, Vim, Emacs, or the Godot game engine**.
+
+## Setup
+
+DiffDetective is a Java Maven library.
+
+...
 
 ## Publications
 
@@ -25,22 +27,28 @@ or by first parsing both versions to an abstract representation, a variation tre
 [![Preprint](https://img.shields.io/badge/Preprint-Read-purple)](https://github.com/SoftVarE-Group/Papers/raw/main/2022/2022-ESECFSE-Bittner.pdf)
 [![Paper](https://img.shields.io/badge/Paper-Read-purple)](https://dl.acm.org/doi/10.1145/3540250.3549108)
 [![Talk](https://img.shields.io/badge/Talk-Watch-purple)](https://www.youtube.com/watch?v=EnDx1AWxD24)
-[![Replication Package](https://img.shields.io/badge/Replication-Package-blue)](replication/esecfse22/README.md)
+[![Original Replication Package](https://img.shields.io/badge/Replication_Package-Original-blue)](https://github.com/VariantSync/DiffDetective/tree/esecfse22)
+[![Updated Replication Package](https://img.shields.io/badge/Replication_Package-Updated-blue)](replication/esecfse22/README.md)
 [![Artifact DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7110095.svg)](https://doi.org/10.5281/zenodo.7110095)
 
 > P. M. Bittner, C.Tinnes, A. Schultheiß, S. Viegener, T. Kehrer, T. Thüm. _Classifying Edits to Variability in Source Code_. In Proceedings of the 30th ACM Joint European Software Engineering Conference and Symposium on the Foundations of Software Engineering (ESEC/FSE 2022), ACM, New York, NY, November 2022
 
 <img padding="10" align="right" src="https://www.acm.org/binaries/content/gallery/acm/publications/artifact-review-v1_1-badges/artifacts_evaluated_reusable_v1_1.png" alt="ACM Artifacts Evaluated Reusable" width="114" height="113"/>
 
-In this work, we used DiffDetective to classify the effect of edits on the variability of the edited source code in the change histories of 44 open-source C-preprocessor-based software projects.
+This was the initial work, introducing DiffDetective as a means to conduct an empirical evaluation of a classification of edits.
+In particular, we used DiffDetective to classify the effect of edits on the variability of the edited source code in the change histories of 44 open-source C-preprocessor-based software projects.
 
-Our replication package and further information can be found in the [README](replication/esecfse22/README.md) file in the respective directory (`replication/esecfse22`).
+The classification is implemented within the [org.variantsync.diffdetective.editclass](src/main/java/org/variantsync/diffdetective/editclass/) package.
+
+The original replication package can be found on the [esecfse](https://github.com/VariantSync/DiffDetective/tree/esecfse22) branch or via the DOI [10.5281/zenodo.7110095](https://doi.org/10.5281/zenodo.7110095). The replication is also available for the most recent version of DiffDetective with various improvements, which will likely yield to slightly different results than the initial study. The updated replication package can be found in the [replication/esecfse22](replication/esecfse22) subdirectory with it's own [README](replication/esecfse22/README.md).
+
 
 ### Views on Edits to Variational Software (SPLC 2023)
 
 [![Preprint](https://img.shields.io/badge/Preprint-Read-purple)](https://github.com/SoftVarE-Group/Papers/raw/main/2023/2023-SPLC-Bittner.pdf)
 [![Paper](https://img.shields.io/badge/Paper-Read-purple)](https://dl.acm.org/doi/10.1145/3579027.3608985)
-[![Replication Package](https://img.shields.io/badge/Replication-Package-blue)](replication/splc23-views/README.md)
+[![Original Replication Package](https://img.shields.io/badge/Replication_Package-Original-blue)](https://github.com/VariantSync/DiffDetective/tree/splc23-views/replication/splc23-views)
+[![Updated Replication Package](https://img.shields.io/badge/Replication_Package-Updated-blue)](replication/splc23-views/README.md)
 [![Artifact DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.8027920.svg)](https://doi.org/10.5281/zenodo.8027920)
 
 > P. M. Bittner, A. Schultheiß, S. Greiner, B. Moosherr, S. Krieter, C. Tinnes, T. Kehrer, T. Thüm. _Views on Edits to Variational Software_. In Proceedings of the 27th ACM International Systems and Software Product Line Conference (SPLC 2023), ACM, New York, NY, August 2023
@@ -50,12 +58,38 @@ Our replication package and further information can be found in the [README](rep
 In this work, we used DiffDetective for a feasibility study of creating views on edits to C-preprocessor based software.
 The idea of a view is to act as a filter on relevant parts of a system.
 For instance, a piece of source code may be deemed relevant if it implements a certain feature.
-
-Views on edits extend views to software changes.
 A view on an edit thus is a simplified form of an edit that, for example, contains only changes to a certain feature.
-We implemented views on edits for variational systems in terms of views on variation diffs.
+From a mathematical perspective, creating such views is in fact a lifting of operations on single revisions of variational systems to operations on diffs of variational systems.
 
-Our replication package and further information can be found in the [README](replication/splc23-views/README.md) file in the respective directory (`replication/splc23-views`).
+Views are implemented within the [org.variantsync.diffdetective.variation.tree.view](src/main/java/org/variantsync/diffdetective/variation/tree/view/) and [org.variantsync.diffdetective.variation.diff.view](src/main/java/org/variantsync/diffdetective/variation/diff/view/) packages for variaton trees and diffs, respectively.
+
+The original replication package can be found on the `splc23-views` branch within the directory [replication/splc23-views](https://github.com/VariantSync/DiffDetective/tree/splc23-views/replication/splc23-views) or via the DOI [10.5281/zenodo.8027920](https://doi.org/10.5281/zenodo.8027920). The replication is also available for the most recent version of DiffDetective with an up-to-date version of DiffDetective, which will likely yield to slightly different results than the initial study. The updated replication package can be found in the [replication/splc23-views](replication/splc23-views) subdirectory with it's own [README](replication/splc23-views/README.md).
+
+
+### Explaining Edits to Variability Annotations in Evolving Software Product Lines (VaMoS 2024)
+
+[![Preprint](https://img.shields.io/badge/Preprint-Read-purple)](https://github.com/SoftVarE-Group/Papers/raw/main/2024/2024-VaMoS-Guething.pdf)
+[![Paper](https://img.shields.io/badge/Paper-Read-purple)](https://doi.org/10.1145/3634713.3634725)
+[![Replication Package](https://img.shields.io/badge/Replication_Package-at_Fork-blue)][forklg]
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10286851.svg)](https://doi.org/10.5281/zenodo.10286851)
+
+> L. Güthing, P. M. Bittner, I. Schaefer, T. Thüm. _Explaining Edits to Variability Annotations in Evolving Software Product Lines_. In Proceedings of the 18th International Working Conference on Variability Modelling of Software-Intensive Systems (VaMoS 2024), ACM, New York, NY, February 2024
+
+<img padding="10" align="right" src="https://www.acm.org/binaries/content/gallery/acm/publications/artifact-review-v1_1-badges/artifacts_evaluated_functional_v1_1.png" alt="ACM Artifacts Evaluated Reusable" width="114" height="113"/>
+
+In this work, we formalized an extension of variation diffs, with a typing for edges and pair-wise relations for variability annotations (i.e., mapping nodes in variation diffs). Such edge-typed variation diffs show for example that two annotations exlude or imply each other. Such edge-typed diffs might help better explaining or analyzing edits in the future.
+
+Edge-typed variation diffs and the replication package are implemented in a fork of DiffDetective ([https://github.com/guethilu/DiffDetective][forklg]). The replication package is archived under the DOI [10.5281/zenodo.10286851](https://doi.org/10.5281/zenodo.10286851).
+
+### Student Theses
+
+DiffDetective was extended and used within bachelor's and master's theses:
+
+- _Constructing Variation Diffs Using Tree Diffing Algorithms_, Benjamin Moosherr, Bachelor's Thesis, 2023, [DOI 10.18725/OPARU-50108](https://dx.doi.org/10.18725/OPARU-50108): Benjamin added support for tree-differencing and integrated the GumTree differencer ([Github](https://github.com/GumTreeDiff/gumtree), [Paper](https://doi.org/10.1145/2642937.2642982)). In his thesis, Benjamin also reviewed a range of quality metrics for tree-diffs with focus on their applicability for rating variability-aware diffs.
+- _Reverse Engineering Feature-Aware Commits From Software Product-Line Repositories_, Lukas Bormann, Bachelor's Thesis, 2023, [10.18725/OPARU-47892](https://dx.doi.org/10.18725/OPARU-47892): Lukas implemented an algorithm for feature-based commit-untangling, which turns variation diff into a series of smaller diffs, each of which contains an edit to a single feature or feature formula. This work was later refined in our publication _Views on Edits to Variational Software_ illustrated above.
+- _Inspecting the Evolution of Feature Annotations in Configurable Software_, Lukas Güthing, Master's Thesis, 2023: Lukas implemented different edge-types for associating variability annotations within variation diffs. He published his work later at VaMoS 2024 under the title _Explaining Edits to Variability Annotations in Evolving Software Product Lines_, illustrated above.
+- _Empirical Evaluation of Feature Trace Recording on the Edit History of Marlin_, Sören Viegener, Bachelor's Thesis, 2021, [DOI 10.18725/OPARU-38603](http://dx.doi.org/10.18725/OPARU-38603): In his thesis, Sören started the DiffDetective project and implemented the first version of an algorithm, which parses text-based diffs to C-preprocessor files to variation diffs. He also came up with an initial classification of edits, which we wanted to reuse to evaluate [Feature Trace Recording](https://variantsync.github.io/FeatureTraceRecording/), a method for deriving variability annotations from annotated patches.
 
 [documentation]: https://htmlpreview.github.io/?https://github.com/VariantSync/DiffDetective/blob/splc23-views/docs/javadoc/index.html
 [website]: https://variantsync.github.io/DiffDetective/
+[forklg]: https://github.com/guethilu/DiffDetective

--- a/README.md
+++ b/README.md
@@ -16,9 +16,37 @@ Additionally, DiffDetective offers a **flexible framework for large-scale empiri
 
 ## Setup
 
-DiffDetective is a Java Maven library.
+DiffDetective is a Java Maven library. While DiffDetective depends on some custom libraries ([FeatureIDE library](https://featureide.github.io/), [Sat4j](https://sat4j.org/), [Functjonal](https://github.com/VariantSync/Functjonal)) these are prepackaged with DiffDetective. So **all you need is [Maven](https://maven.apache.org/)** installed.
 
-...
+DiffDetective also comes as a **nix package** (see [default.nix](default.nix)).
+
+### Setup with Maven
+
+First, clone this repository and navigate inside it:
+```shell
+git clone https://github.com/VariantSync/DiffDetective
+cd DiffDetective
+```
+
+Second, build DiffDetective and install it on your system so that you can access it from your own projects:
+```shell
+mvn install
+```
+
+DiffDetective is now available on your system. Add the following to the pom.xml of your Maven project to add DiffDetective as a dependency, but make sure to pick the right version. You can the current version of DiffDetective you installed at the top of the pom.xml file in DiffDetective. 
+
+```xml
+<dependency>
+    <groupId>org.variantsync</groupId>
+    <artifactId>DiffDetective</artifactId>
+    <version>2.0.0</version>
+</dependency>
+```
+
+If you prefer to just use a jar file, you can find a jar file with all dependencies in `DiffDetective/target/diffdetective-2.0.0-jar-with-dependencies.jar` (again, the version number might be different).
+You can (re-)produce this jar file by either running `mvn package` or `mvn install` within you local clone of DiffDetective.
+
+> Disclaimer: Setup tested with maven version 3.6.3.
 
 ## Publications
 


### PR DESCRIPTION
The README of DiffDetective is horribly plain and outdated. I added setup instructions, and an overview on our paper's and theses. @ibbem Could you add a quick note on the nix setup (as a new heading `### Setup with Nix` below the `Setup with Maven` instructions)?