### PR TITLE
Fix GitHub pages style sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ nix build # Flake version
 ```
 In case you are using Nix Flakes, you can skip cloning the repository as usual: `nix build github:VariantSync/DiffDetective#.`
 
-Afterward, the [result](result) symlink points to the [Javadoc](result/share/github-pages/docs/javadoc/index.html), the [DiffDetective jar](result/share/java/DiffDetective/DiffDetective.jar) and a simple [script](result/bin/DiffDetective) for executing a DiffDetective main class provided as argument (e.g., evaluations used in previous research, see below under 'Publications').
+Afterward, the [result](result) symlink points to the [Javadoc](result/share/github-pages/DiffDetective/docs/javadoc/index.html), the [DiffDetective jar](result/share/java/DiffDetective/DiffDetective.jar) and a simple [script](result/bin/DiffDetective) for executing a DiffDetective main class provided as argument (e.g., evaluations used in previous research, see below under 'Publications').
 
 ## Publications
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,2 @@
 theme: jekyll-theme-cayman
+baseurl: DiffDetective

--- a/default.nix
+++ b/default.nix
@@ -73,7 +73,7 @@ pkgs.stdenv.mkDerivation rec {
       if buildGitHubPages
       then ''
         mvn javadoc:javadoc
-        PAGES_REPO_NWO=VariantSync/DiffDetective JEKYLL_BUILD_REVISION= github-pages build
+        JEKYLL_ENV=production PAGES_REPO_NWO=VariantSync/DiffDetective JEKYLL_BUILD_REVISION= github-pages build
       ''
       else ""
     }
@@ -102,7 +102,8 @@ pkgs.stdenv.mkDerivation rec {
     ${
       if buildGitHubPages
       then ''
-        cp -r _site "$out/share/github-pages"
+        mkdir "$out/share/github-pages"
+        cp -r _site "$out/share/github-pages/DiffDetective"
       ''
       else ""
     }


### PR DESCRIPTION
Previously, Jekyll assumed that assets can be found in a top-level directory which is not actually the case.