### PR TITLE
Single source of truth for the DiffDetective version

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Next, build DiffDetective and install it on your system so that you can access i
 mvn install
 ```
 
-To add DiffDetective as a dependency to your own project, add the following snippet to the pom.xml of your Maven project, but make sure to pick the right version number. You can find the version number of DiffDetective at the top of the pom.xml file of DiffDetective. 
+To add DiffDetective as a dependency to your own project, add the following snippet to the pom.xml of your Maven project, but make sure to pick the right version number. The current version number can be obtained by running `scripts/version.sh`
 
 ```xml
 <dependency>

--- a/default.nix
+++ b/default.nix
@@ -10,7 +10,7 @@
   doCheck ? true,
   buildGitHubPages ? true,
 }:
-pkgs.stdenv.mkDerivation rec {
+pkgs.stdenvNoCC.mkDerivation rec {
   pname = "DiffDetective";
   version = "2.2.0";
   src = with pkgs.lib.fileset;

--- a/default.nix
+++ b/default.nix
@@ -12,7 +12,11 @@
 }:
 pkgs.stdenvNoCC.mkDerivation rec {
   pname = "DiffDetective";
-  version = "2.2.0";
+  # The single source of truth for the version number is stored in `pom.xml`.
+  # Hence, this XML file needs to be parsed to extract the current version.
+  version = pkgs.lib.removeSuffix "\n" (pkgs.lib.readFile
+    (pkgs.runCommandLocal "DiffDetective-version" {}
+      "${pkgs.xq-xml}/bin/xq -x '/project/version' ${./pom.xml} > $out"));
   src = with pkgs.lib.fileset;
     toSource {
       root = ./.;

--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,7 @@
 
     <groupId>org.variantsync</groupId>
     <artifactId>diffdetective</artifactId>
+    <!-- The DiffDetective version, needs to be the first version tag in this file. -->
     <version>2.2.0</version>
 
     <properties>

--- a/replication/esecfse22/Dockerfile
+++ b/replication/esecfse22/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR /home/sherlock
 # Copy the compiled JAR file from the first stage into the second stage
 # Syntax: COPY --from=STAGE_ID SOURCE_PATH TARGET_PATH
 WORKDIR /home/sherlock/holmes
-COPY --from=0 /home/user/target/diffdetective-2.2.0-jar-with-dependencies.jar ./DiffDetective.jar
+COPY --from=0 /home/user/target/diffdetective-*-jar-with-dependencies.jar ./DiffDetective.jar
 WORKDIR /home/sherlock
 RUN mkdir results
 

--- a/replication/splc23-views/Dockerfile
+++ b/replication/splc23-views/Dockerfile
@@ -38,7 +38,7 @@ WORKDIR /home/sherlock
 # Copy the compiled JAR file from the first stage into the second stage
 # Syntax: COPY --from=STAGE_ID SOURCE_PATH TARGET_PATH
 WORKDIR /home/sherlock/holmes
-COPY --from=0 /home/user/target/diffdetective-2.2.0-jar-with-dependencies.jar ./DiffDetective.jar
+COPY --from=0 /home/user/target/diffdetective-*-jar-with-dependencies.jar ./DiffDetective.jar
 WORKDIR /home/sherlock
 
 # Copy the setup

--- a/scripts/genUltimateResults.sh
+++ b/scripts/genUltimateResults.sh
@@ -1,4 +1,4 @@
 resultsdir=$1
 
-java -cp "target/diffdetective-2.2.0-jar-with-dependencies.jar" org.variantsync.diffdetective.tablegen.MiningResultAccumulator $resultsdir $resultsdir
+java -cp "target/diffdetective-$(./scripts/version.sh)-jar-with-dependencies.jar" org.variantsync.diffdetective.tablegen.MiningResultAccumulator $resultsdir $resultsdir
 echo "genUltimateResults.sh DONE"

--- a/scripts/genUltimateResults.sh
+++ b/scripts/genUltimateResults.sh
@@ -1,4 +1,8 @@
-resultsdir=$1
+#!/usr/bin/env bash
 
-java -cp "target/diffdetective-$(./scripts/version.sh)-jar-with-dependencies.jar" org.variantsync.diffdetective.tablegen.MiningResultAccumulator $resultsdir $resultsdir
+resultsdir="$1"
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 1
+
+java -cp "target/diffdetective-$(./scripts/version.sh)-jar-with-dependencies.jar" org.variantsync.diffdetective.tablegen.MiningResultAccumulator "$resultsdir" "$resultsdir" &&
 echo "genUltimateResults.sh DONE"

--- a/scripts/runValidation.sh
+++ b/scripts/runValidation.sh
@@ -1,2 +1,2 @@
-java -cp "target/diffdetective-2.2.0-jar-with-dependencies.jar" org.variantsync.diffdetective.validation.EditClassValidation
+java -cp "target/diffdetective-$(./scripts/version.sh)-jar-with-dependencies.jar" org.variantsync.diffdetective.validation.EditClassValidation
 echo "runValidation.sh DONE"

--- a/scripts/runValidation.sh
+++ b/scripts/runValidation.sh
@@ -1,2 +1,6 @@
-java -cp "target/diffdetective-$(./scripts/version.sh)-jar-with-dependencies.jar" org.variantsync.diffdetective.validation.EditClassValidation
+#!/usr/bin/env bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 1
+
+java -cp "target/diffdetective-$(./scripts/version.sh)-jar-with-dependencies.jar" org.variantsync.diffdetective.validation.EditClassValidation &&
 echo "runValidation.sh DONE"

--- a/scripts/runViewFeasibilityStudy.sh
+++ b/scripts/runViewFeasibilityStudy.sh
@@ -1,2 +1,2 @@
-java -cp "target/diffdetective-2.2.0-jar-with-dependencies.jar" org.variantsync.diffdetective.experiments.views.Main "docs/datasets/views.md"
+java -cp "target/diffdetective-$(./scripts/version.sh)-jar-with-dependencies.jar" org.variantsync.diffdetective.experiments.views.Main "docs/datasets/views.md"
 echo "runValidation.sh DONE"

--- a/scripts/runViewFeasibilityStudy.sh
+++ b/scripts/runViewFeasibilityStudy.sh
@@ -1,2 +1,6 @@
-java -cp "target/diffdetective-$(./scripts/version.sh)-jar-with-dependencies.jar" org.variantsync.diffdetective.experiments.views.Main "docs/datasets/views.md"
+#!/usr/bin/env bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 1
+
+java -cp "target/diffdetective-$(./scripts/version.sh)-jar-with-dependencies.jar" org.variantsync.diffdetective.experiments.views.Main "docs/datasets/views.md" &&
 echo "runValidation.sh DONE"

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+# extracts the first version tag in pom.xml
+sed -n '/<version/ {s/.*version>\(.*\)<\/version.*/\1/; p; q}' pom.xml


### PR DESCRIPTION
As discussed in #134, we want to be able to edit the version number of DiffDetective in one single place: the `pom.xml`. There is no alternative to using `pom.xml` (e.g., using `default.nix`) because `pom.xml` doesn't support inclusion of other files (except XML files). Fortunately, the shell and Nix are both flexible enough to support this (although it's uncommon to parse XML in Nix, hence this complicated expression).
However, the shell scripts are more brittle now because they will fail if multiple versions of DiffDetective jars exist. Do we even need these scripts anymore? If yes, it would make sense to give them a little love (e.g., they always print DONE, even in case of errors, etc.).

The only place where the version number is still duplicated is the `README.md`. However, there is a note where to find the actual current version so this should be fine.