### PR TITLE
Use reproducible time stamps for Maven build artifacts

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -67,6 +67,7 @@ pkgs.stdenv.mkDerivation rec {
       then ''
         mvn javadoc:javadoc
         JEKYLL_ENV=production PAGES_REPO_NWO=VariantSync/DiffDetective JEKYLL_BUILD_REVISION= github-pages build
+        rm -rf _site/target
       ''
       else ""
     }

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <!-- Override the time stamps of build artifacts to ensure reproducibility -->
+        <project.build.outputTimestamp>1</project.build.outputTimestamp>
     </properties>
 
     <build>


### PR DESCRIPTION
Unfortunately, JAR files store time stamps of the files inside them.
These time stamps depend on the build time of these files hence breaking
bit for bit reproducibility. By setting all time stamps to a predefined
value and removing superfluous build artifacts this issue can be
avoided. Conventionally, UNIX time stamp 1 signifies an intentionally
set time stamp (in contrast to UNIX time stamp 0) which has no meaning
and is easy to recognize.

I noticed this issue today after reading the following blog post: https://fzakaria.com/2021/06/28/java-nix-reproducibility.html
I also verified that this is indeed an issue in DiffDetective and that it's solved by this PR.