### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,6 +8,7 @@ on:
     branches: [ "main", "develop" ]
   pull_request:
     branches:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -50,3 +50,9 @@ jobs:
     - name: Publish Javadoc to Github Pages
       id: deployment
       uses: actions/deploy-pages@v1
+
+    # Kill in progress deployments because only the newest version is relevant
+    # and concurrent deployments cause CI failures.
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true


### PR DESCRIPTION
- make CI interruptible: So when we push, and there is a CI job running, then interrupt the current CI job and restart it instead of crashing.
- enable manual workflow runs on Github, see:
  - https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow
  - https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch