### PR TITLE
Fix javadoc deployment

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -122,6 +122,7 @@ pkgs.stdenvNoCC.mkDerivation rec {
       if buildGitHubPages
       then ''
         mvn javadoc:javadoc
+        mv target/reports/apidocs docs/javadoc
         JEKYLL_ENV=production PAGES_REPO_NWO=VariantSync/DiffDetective JEKYLL_BUILD_REVISION= PAGES_DISABLE_NETWORK=1 github-pages build
         rm -rf _site/target
       ''

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,6 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.11.2</version>
                 <configuration>
-                    <reportOutputDirectory>docs</reportOutputDirectory>
-                    <destDir>javadoc</destDir>
                     <show>private</show>
                     <quiet>true</quiet>
                 </configuration>


### PR DESCRIPTION
The dependency update of the maven-javadoc-plugin in afd65e1d9079b9d1ea698c9ffb9e3322914e10c5 removed the possibility to define an alternative output directory for the generated javadoc which resulted in a warning that I missed until now. This regression was intentional and is declared as won't fix by upstream. See https://github.com/apache/maven-javadoc-plugin/issues/1194
Hence, we need to move the javadoc directory manually to include it in the correct location in the GitHub Pages.

This is a blocker for #157.