### PR TITLE
Assert that there is at most one else in `assertConsistency`

### DIFF
--- a/src/main/java/org/variantsync/diffdetective/variation/diff/DiffNode.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/DiffNode.java
@@ -733,6 +733,7 @@ public class DiffNode<L extends Label> implements HasNodeType {
      * Checks that the VariationDiff is in a valid state.
      * In particular, this method checks that all edges are well-formed (e.g., edges can be inconsistent because edges are double-linked).
      * This method also checks that a node with exactly one parent was edited, and that a node with exactly two parents was not edited.
+     * To check all children recursively, use {@link VariationDiff#assertConsistency}.
      * @see Assert#assertTrue
      * @throws AssertionError when an inconsistency is detected.
      */

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/DiffNode.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/DiffNode.java
@@ -737,6 +737,9 @@ public class DiffNode<L extends Label> implements HasNodeType {
      * @throws AssertionError when an inconsistency is detected.
      */
     public void assertConsistency() {
+        // check that the projections are valid (i.e., node type specific consistency checks)
+        diffType.forAllTimesOfExistence(time -> this.projection(time).assertConsistency());
+
         // check consistency of children lists and edges
         for (final DiffNode<L> c : getAllChildren()) {
             Assert.assertTrue(isChild(c), () -> "Child " + c + " of " + this + " is neither a before nor an after child!");
@@ -769,22 +772,6 @@ public class DiffNode<L extends Label> implements HasNodeType {
             if (pb == pa) {
                 Assert.assertTrue(pb.isNon());
             }
-        }
-
-        // Else and Elif nodes have an If or Elif as parent.
-        if (this.isElse() || this.isElif()) {
-            Time.forAll(time -> {
-                if (getParent(time) != null) {
-                    Assert.assertTrue(getParent(time).isIf() || getParent(time).isElif(), time + " parent " + getParent(time) + " of " + this + " is neither IF nor ELIF!");
-                }
-            });
-        }
-
-        // Only if and elif nodes have a formula
-        if (this.isIf() || this.isElif()) {
-            Assert.assertTrue(this.getFormula() != null, "If or elif without feature mapping!");
-        } else {
-            Assert.assertTrue(this.getFormula() == null, "Node with type " + getNodeType() + " has a non null feature mapping");
         }
     }
 

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/DiffNode.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/DiffNode.java
@@ -763,6 +763,10 @@ public class DiffNode<L extends Label> implements HasNodeType {
         if (pb != null && pa == null) {
             Assert.assertTrue(isRem());
         }
+        // the root was not edited
+        if (pb == null && pa == null) {
+            Assert.assertTrue(isNon());
+        }
         // a node with exactly two parents was not edited
         if (pb != null && pa != null) {
             Assert.assertTrue(isNon());

--- a/src/main/java/org/variantsync/diffdetective/variation/diff/Projection.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/diff/Projection.java
@@ -130,4 +130,9 @@ public class Projection<L extends Label> extends VariationNode<Projection<L>, L>
     public int getID() {
         return getBackingNode().getID();
     }
+
+    @Override
+    public String toString() {
+        return String.format("Projection(%s, %s)", time, getBackingNode());
+    }
 };

--- a/src/main/java/org/variantsync/diffdetective/variation/tree/VariationNode.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/tree/VariationNode.java
@@ -487,26 +487,28 @@ public abstract class VariationNode<T extends VariationNode<T, L>, L extends Lab
     }
 
     /**
-    * Checks that this node satisfies some easy to check invariants.
-    * In particular, this method checks that
-    * <ul>
-    * <li>if-chains are nested correctly,
-    * <li>the root is an {@link NodeType#IF} with the feature mapping {@code "true"},
-    * <li>the feature mapping is {@code null} iff {@code isConditionalAnnotation} is {@code false}
-    * and
-    * <li>all edges are well-formed (e.g., edges can be inconsistent because edges are
-    * double-linked).
-    * </ul>
-    *
-    * <p>Some invariants are not checked. These include
-    * <ul>
-    * <li>There should be no cycles and
-    * <li>{@link getID} should be unique in the whole variation tree.
-    * </ul>
-    *
-    * @see Assert#assertTrue
-    * @throws AssertionError when an inconsistency is detected.
-    */
+     * Checks that this node satisfies some easy to check invariants.
+     * In particular, this method checks that
+     * <ul>
+     * <li>if-chains are nested correctly,
+     * <li>the root is an {@link NodeType#IF} with the feature mapping {@code "true"},
+     * <li>the feature mapping is {@code null} iff {@code isConditionalAnnotation} is {@code false}
+     * and
+     * <li>all edges are well-formed (e.g., edges can be inconsistent because edges are
+     * double-linked).
+     * </ul>
+     *
+     * <p>Some invariants are not checked. These include
+     * <ul>
+     * <li>There should be no cycles,
+     * <li>{@link getID} should be unique in the whole variation tree, and
+     * <li>children are not checked recursively.
+     * </ul>
+     * Use {@link VariationTree#assertConsistency} to check all children recursively.
+     *
+     * @see Assert#assertTrue
+     * @throws AssertionError when an inconsistency is detected.
+     */
     public void assertConsistency() {
         // ELSE and ELIF nodes have an IF or ELIF as parent.
         if (isElse() || isElif()) {

--- a/src/main/java/org/variantsync/diffdetective/variation/tree/VariationNode.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/tree/VariationNode.java
@@ -537,6 +537,12 @@ public abstract class VariationNode<T extends VariationNode<T, L>, L extends Lab
                 "The root has to have the feature mapping 'true'");
         }
 
+        // check that there is at most one ELIF/ELSE
+        Assert.assertTrue(
+            getChildren().stream().filter(c -> c.isElif() || c.isElse()).count() <= 1,
+            "There is more than one ELIF/ELSE node."
+        );
+
         // check consistency of children lists and edges
         for (var child : getChildren()) {
             Assert.assertTrue(

--- a/src/main/java/org/variantsync/diffdetective/variation/tree/VariationTree.java
+++ b/src/main/java/org/variantsync/diffdetective/variation/tree/VariationTree.java
@@ -5,6 +5,7 @@ import org.variantsync.diffdetective.diff.result.DiffParseException;
 import org.variantsync.diffdetective.util.Assert;
 import org.variantsync.diffdetective.variation.DiffLinesLabel;
 import org.variantsync.diffdetective.variation.Label;
+import org.variantsync.diffdetective.variation.NodeType; // For Javadoc
 import org.variantsync.diffdetective.variation.diff.DiffNode;
 import org.variantsync.diffdetective.variation.diff.VariationDiff;
 import org.variantsync.diffdetective.variation.diff.Projection;
@@ -211,6 +212,17 @@ public record VariationTree<L extends Label>(
         var result = new StringBuilder();
         root().unparse(result);
         return result.toString();
+    }
+
+    /**
+     * Checks whether this {@link VariationTree} is consistent.
+     * Throws an error if this {@link VariationTree} is inconsistent (e.g., if there are multiple
+     * {@link NodeType#ELSE} nodes). Has no side-effects otherwise.
+     *
+     * @see VariationNode#assertConsistency
+     */
+    public void assertConsistency() {
+        forAllPreorder(VariationTreeNode::assertConsistency);
     }
 
     @Override


### PR DESCRIPTION
This was originally discussed in https://github.com/VariantSync/DiffDetective/pull/174#issuecomment-3448232443